### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Continuous Integration
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/cookeyholder/AlleyNote/security/code-scanning/6](https://github.com/cookeyholder/AlleyNote/security/code-scanning/6)

The best fix is to add a `permissions:` block limiting GITHUB_TOKEN scope to the minimum needed, which for this CI workflow is `contents: read`. This can be set at the workflow root to apply to all jobs, or specifically inside the `tests` job definition. As this workflow only checks out code and runs tests, `contents: read` is sufficient and recommended. Edit `.github/workflows/ci.yml` and add the following at the top-level (between the `name:` and `on:` fields) or inside `jobs.tests:` before `runs-on:`. The fix does not require any additional imports or definitions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
