### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,8 @@
 name: Security Audit
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop, feature/*]


### PR DESCRIPTION
Potential fix for [https://github.com/cookeyholder/AlleyNote/security/code-scanning/3](https://github.com/cookeyholder/AlleyNote/security/code-scanning/3)

The best fix is to explicitly add a `permissions` block that limits the GITHUB_TOKEN’s capabilities. As the workflow only checks out code and uploads artifacts (no pushing, PRs, deployments, or workflow writes), the minimal required permission is `contents: read`. This can be safely added either at the root of the workflow file (preferred, as there is only one job), or directly inside the `security-audit` job. The change should be placed after the workflow `name:` and before or after `on:` at the root level (before `jobs:`), so that all jobs inherit these minimal permissions. No additional imports, methods, or definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
