### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -1,3 +1,6 @@
+permissions:
+    contents: write
+    pull-requests: write
 name: Dependency Updates
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/cookeyholder/AlleyNote/security/code-scanning/2](https://github.com/cookeyholder/AlleyNote/security/code-scanning/2)

To address this issue, you should add a `permissions` block to the workflow to explicitly limit the permissions granted to the GITHUB_TOKEN. The minimal starting point is `contents: read`, but, due to the workflow's need to commit changes to a branch and create a pull request, you'll need to grant `contents: write` and `pull-requests: write`. You can add the following block near the top of the workflow, just after `name:` and before `on:`, so the permissions apply to all jobs in the workflow (none of the jobs have their own `permissions` blocks). No new imports or methods are required; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
