### PR TITLE
refactor: 萃取 CacheInterface 統一快取介面階層

### DIFF
--- a/backend/app/Infrastructure/Services/CacheService.php
+++ b/backend/app/Infrastructure/Services/CacheService.php
@@ -35,25 +35,25 @@ class CacheService implements CacheServiceInterface
         }
     }
 
-    public function get(string $key): mixed
+    public function get(string $key, mixed $default = null): mixed
     {
         $filename = $this->getCacheFilename($key);
         if (!file_exists($filename)) {
             $this->incrementStat('misses');
 
-            return null;
+            return $default;
         }
         $data = file_get_contents($filename);
         if ($data === false) {
             $this->incrementStat('misses');
 
-            return null;
+            return $default;
         }
         $cacheData = json_decode($data, true);
         if (!is_array($cacheData) || !isset($cacheData['expiry'], $cacheData['data'])) {
             $this->incrementStat('misses');
 
-            return null;
+            return $default;
         }
         $expiry = $cacheData['expiry'];
         if (!is_int($expiry)) {
@@ -62,14 +62,14 @@ class CacheService implements CacheServiceInterface
             } else {
                 $this->incrementStat('misses');
 
-                return null;
+                return $default;
             }
         }
         if (time() > $expiry) {
             $this->delete($key);
             $this->incrementStat('misses');
 
-            return null;
+            return $default;
         }
         $this->incrementStat('hits');
 
@@ -143,13 +143,13 @@ class CacheService implements CacheServiceInterface
         return true;
     }
 
-    public function remember(string $key, callable $callback, ?int $ttl = null): mixed
+    public function remember(string $key, callable $callback, int $ttl = 3600): mixed
     {
         $value = $this->get($key);
         if ($value === null) {
             $value = $callback();
             if ($value !== null) {
-                $this->set($key, $value, $ttl ?: self::TTL);
+                $this->set($key, $value, $ttl);
             }
         }
 

--- a/backend/app/Infrastructure/Services/CacheService.php
+++ b/backend/app/Infrastructure/Services/CacheService.php
@@ -76,7 +76,7 @@ class CacheService implements CacheServiceInterface
         return $cacheData['data'];
     }
 
-    public function set(string $key, mixed $value, int $ttl = 3600): bool
+    public function set(string $key, mixed $value, ?int $ttl = null): bool
     {
         $filename = $this->getCacheFilename($key);
         $this->incrementStat('sets');
@@ -143,7 +143,7 @@ class CacheService implements CacheServiceInterface
         return true;
     }
 
-    public function remember(string $key, callable $callback, int $ttl = 3600): mixed
+    public function remember(string $key, callable $callback, ?int $ttl = null): mixed
     {
         $value = $this->get($key);
         if ($value === null) {
@@ -172,7 +172,7 @@ class CacheService implements CacheServiceInterface
         return $result;
     }
 
-    public function setMultiple(array $values, int $ttl = 3600): bool
+    public function setMultiple(array $values, ?int $ttl = null): bool
     {
         foreach ($values as $key => $value) {
             $this->set($this->normalizeKey($key), $value, $ttl);

--- a/backend/app/Shared/Cache/Contracts/CacheInterface.php
+++ b/backend/app/Shared/Cache/Contracts/CacheInterface.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Cache\Contracts;
+
+interface CacheInterface
+{
+    /**
+     * 從快取中取得資料。
+     *
+     * @param string $key 快取鍵
+     * @param mixed $default 預設回傳值
+     *
+     * @return mixed 快取的資料，若不存在則回傳 $default
+     */
+    public function get(string $key, mixed $default = null): mixed;
+
+    /**
+     * 將資料存入快取。
+     *
+     * @param string $key 快取鍵
+     * @param mixed $value 要快取的資料
+     * @param int $ttl 存活時間（秒）
+     *
+     * @return bool 是否成功存入
+     */
+    public function set(string $key, mixed $value, int $ttl = 3600): bool;
+
+    /**
+     * 檢查快取鍵是否存在。
+     *
+     * @param string $key 快取鍵
+     *
+     * @return bool 是否存在
+     */
+    public function has(string $key): bool;
+
+    /**
+     * 刪除快取。
+     *
+     * @param string $key 快取鍵
+     *
+     * @return bool 是否成功刪除
+     */
+    public function delete(string $key): bool;
+
+    /**
+     * 清空所有快取。
+     *
+     * @return bool 是否成功清空
+     */
+    public function clear(): bool;
+
+    /**
+     * 記憶化快取 - 如果快取不存在則執行回調並快取結果。
+     *
+     * @param string $key 快取鍵
+     * @param callable $callback 回調函式
+     * @param int $ttl 存活時間（秒）
+     *
+     * @return mixed 快取的資料或回調結果
+     */
+    public function remember(string $key, callable $callback, int $ttl = 3600): mixed;
+
+    /**
+     * 取得快取統計資訊。
+     *
+     * @return array 包含命中率、快取數量等統計資訊
+     */
+    public function getStats(): array;
+}

--- a/backend/app/Shared/Cache/Contracts/CacheInterface.php
+++ b/backend/app/Shared/Cache/Contracts/CacheInterface.php
@@ -21,11 +21,11 @@ interface CacheInterface
      *
      * @param string $key 快取鍵
      * @param mixed $value 要快取的資料
-     * @param int $ttl 存活時間（秒）
+     * @param int|null $ttl 存活時間（秒），null 使用實作預設值
      *
      * @return bool 是否成功存入
      */
-    public function set(string $key, mixed $value, int $ttl = 3600): bool;
+    public function set(string $key, mixed $value, ?int $ttl = null): bool;
 
     /**
      * 檢查快取鍵是否存在。
@@ -57,11 +57,11 @@ interface CacheInterface
      *
      * @param string $key 快取鍵
      * @param callable $callback 回調函式
-     * @param int $ttl 存活時間（秒）
+     * @param int|null $ttl 存活時間（秒），null 使用實作預設值
      *
      * @return mixed 快取的資料或回調結果
      */
-    public function remember(string $key, callable $callback, int $ttl = 3600): mixed;
+    public function remember(string $key, callable $callback, ?int $ttl = null): mixed;
 
     /**
      * 取得快取統計資訊。

--- a/backend/app/Shared/Cache/Contracts/CacheManagerInterface.php
+++ b/backend/app/Shared/Cache/Contracts/CacheManagerInterface.php
@@ -4,38 +4,8 @@ declare(strict_types=1);
 
 namespace App\Shared\Cache\Contracts;
 
-interface CacheManagerInterface
+interface CacheManagerInterface extends CacheInterface
 {
-    /**
-     * 取得快取資料。
-     */
-    public function get(string $key, mixed $default = null): mixed;
-
-    /**
-     * 設定快取資料。
-     */
-    public function set(string $key, mixed $value, int $ttl = 3600): bool;
-
-    /**
-     * 檢查快取是否存在。
-     */
-    public function has(string $key): bool;
-
-    /**
-     * 刪除快取。
-     */
-    public function delete(string $key): bool;
-
-    /**
-     * 清空所有快取。
-     */
-    public function clear(): bool;
-
-    /**
-     * 記憶化取得。
-     */
-    public function remember(string $key, callable $callback, int $ttl = 3600): mixed;
-
     /**
      * 取得或設定標籤化快取。
      *
@@ -52,11 +22,6 @@ interface CacheManagerInterface
      * 取得指定驅動的快取實例。
      */
     public function driver(?string $driver = null): CacheDriverInterface;
-
-    /**
-     * 取得快取統計資訊。
-     */
-    public function getStats(): array;
 
     /**
      * 取得所有驅動的健康狀態。

--- a/backend/app/Shared/Cache/Services/CacheManager.php
+++ b/backend/app/Shared/Cache/Services/CacheManager.php
@@ -435,9 +435,9 @@ class CacheManager implements CacheManagerInterface
         return false;
     }
 
-    public function set(string $key, mixed $value, int $ttl = 3600): bool
+    public function set(string $key, mixed $value, ?int $ttl = null): bool
     {
-        return $this->put($key, $value, $ttl);
+        return $this->put($key, $value, $ttl ?? 3600);
     }
 
     public function delete(string $key): bool
@@ -450,7 +450,7 @@ class CacheManager implements CacheManagerInterface
         return $this->flush();
     }
 
-    public function remember(string $key, callable $callback, int $ttl = 3600): mixed
+    public function remember(string $key, callable $callback, ?int $ttl = null): mixed
     {
         $value = $this->get($key);
         if ($value !== null) {
@@ -459,7 +459,7 @@ class CacheManager implements CacheManagerInterface
 
         try {
             $value = $this->strategy->handleMiss($key, $callback);
-            $this->put($key, $value, $ttl);
+            $this->put($key, $value, $ttl ?? 3600);
 
             return $value;
         } catch (Throwable $e) {

--- a/backend/app/Shared/Cache/Services/PrefixedCacheManager.php
+++ b/backend/app/Shared/Cache/Services/PrefixedCacheManager.php
@@ -20,7 +20,7 @@ class PrefixedCacheManager implements CacheManagerInterface
         return $this->manager->get($this->prefixKey($key), $default);
     }
 
-    public function set(string $key, mixed $value, int $ttl = 3600): bool
+    public function set(string $key, mixed $value, ?int $ttl = null): bool
     {
         return $this->manager->set($this->prefixKey($key), $value, $ttl);
     }
@@ -40,7 +40,7 @@ class PrefixedCacheManager implements CacheManagerInterface
         return $this->manager->clear();
     }
 
-    public function remember(string $key, callable $callback, int $ttl = 3600): mixed
+    public function remember(string $key, callable $callback, ?int $ttl = null): mixed
     {
         return $this->manager->remember($this->prefixKey($key), $callback, $ttl);
     }

--- a/backend/app/Shared/Contracts/CacheServiceInterface.php
+++ b/backend/app/Shared/Contracts/CacheServiceInterface.php
@@ -4,55 +4,12 @@ declare(strict_types=1);
 
 namespace App\Shared\Contracts;
 
-interface CacheServiceInterface
+use App\Shared\Cache\Contracts\CacheInterface;
+
+interface CacheServiceInterface extends CacheInterface
 {
     /**
-     * 從快取中取得資料.
-     *
-     * @param string $key 快取鍵
-     *
-     * @return mixed 快取的資料，若不存在則返回 null
-     */
-    public function get(string $key): mixed;
-
-    /**
-     * 將資料存入快取.
-     *
-     * @param string $key 快取鍵
-     * @param mixed $value 要快取的資料
-     * @param int $ttl 存活時間（秒），0 表示永不過期
-     *
-     * @return bool 是否成功存入
-     */
-    public function set(string $key, mixed $value, int $ttl = 3600): bool;
-
-    /**
-     * 檢查快取鍵是否存在.
-     *
-     * @param string $key 快取鍵
-     *
-     * @return bool 是否存在
-     */
-    public function has(string $key): bool;
-
-    /**
-     * 刪除快取.
-     *
-     * @param string $key 快取鍵
-     *
-     * @return bool 是否成功刪除
-     */
-    public function delete(string $key): bool;
-
-    /**
-     * 清空所有快取.
-     *
-     * @return bool 是否成功清空
-     */
-    public function clear(): bool;
-
-    /**
-     * 批次取得多個快取.
+     * 批次取得多個快取。
      *
      * @param array<string, mixed> $keys 快取鍵陣列
      *
@@ -61,7 +18,7 @@ interface CacheServiceInterface
     public function getMultiple(array $keys): array;
 
     /**
-     * 批次設定多個快取.
+     * 批次設定多個快取。
      *
      * @param array<string, mixed> $values 快取資料陣列，格式為 [key => value]
      * @param int $ttl 存活時間（秒）
@@ -71,7 +28,7 @@ interface CacheServiceInterface
     public function setMultiple(array $values, int $ttl = 3600): bool;
 
     /**
-     * 批次刪除多個快取.
+     * 批次刪除多個快取。
      *
      * @param array<string, mixed> $keys 快取鍵陣列
      *
@@ -80,29 +37,11 @@ interface CacheServiceInterface
     public function deleteMultiple(array $keys): bool;
 
     /**
-     * 依照模式刪除快取.
+     * 依照模式刪除快取。
      *
      * @param string $pattern 快取鍵模式（支援萬用字元）
      *
      * @return int 刪除的快取數量
      */
     public function deletePattern(string $pattern): int;
-
-    /**
-     * 取得快取統計資訊.
-     *
-     * @return array 包含命中率、快取數量等統計資訊
-     */
-    public function getStats(): array;
-
-    /**
-     * 記憶化快取 - 如果快取不存在則執行回調並快取結果.
-     *
-     * @param string $key 快取鍵
-     * @param callable $callback 回調函式
-     * @param int|null $ttl 存活時間（秒），null 使用預設值
-     *
-     * @return mixed 快取的資料或回調結果
-     */
-    public function remember(string $key, callable $callback, ?int $ttl = null): mixed;
 }

--- a/backend/app/Shared/Contracts/CacheServiceInterface.php
+++ b/backend/app/Shared/Contracts/CacheServiceInterface.php
@@ -21,11 +21,11 @@ interface CacheServiceInterface extends CacheInterface
      * 批次設定多個快取。
      *
      * @param array<string, mixed> $values 快取資料陣列，格式為 [key => value]
-     * @param int $ttl 存活時間（秒）
+     * @param int|null $ttl 存活時間（秒），null 使用實作預設值
      *
      * @return bool 是否全部成功設定
      */
-    public function setMultiple(array $values, int $ttl = 3600): bool;
+    public function setMultiple(array $values, ?int $ttl = null): bool;
 
     /**
      * 批次刪除多個快取。

--- a/openspec/changes/cache-interface-unification/.openspec.yaml
+++ b/openspec/changes/cache-interface-unification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/cache-interface-unification/design.md
+++ b/openspec/changes/cache-interface-unification/design.md
@@ -1,0 +1,76 @@
+## Context
+
+`CacheServiceInterface`（`App\Shared\Contracts`）與 `CacheManagerInterface`（`App\Shared\Cache\Contracts`）各自獨立定義了 7 個功能重疊的核心方法：`get`、`set`、`has`、`delete`、`clear`、`remember`、`getStats`。這些方法在兩個介面中的簽章並非完全一致：
+
+| 方法 | CacheServiceInterface | CacheManagerInterface |
+|------|----------------------|-----------------------|
+| `get` | `get(string $key): mixed` | `get(string $key, mixed $default = null): mixed` |
+| `remember` | `remember(string $key, callable $callback, ?int $ttl = null): mixed` | `remember(string $key, callable $callback, int $ttl = 3600): mixed` |
+
+其餘核心方法（`set`、`has`、`delete`、`clear`、`getStats`）簽章完全一致。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 提取共用的 `CacheInterface`，統一核心方法簽章
+- `CacheServiceInterface` 與 `CacheManagerInterface` 皆繼承 `CacheInterface`，消除重複方法定義
+- 維持向後相容 — 所有呼叫端不需修改；`CacheManager` 與 `PrefixedCacheManager` 實作不需修改；`CacheService` 僅需微調 `get()` 與 `remember()` 簽章以匹配統一介面
+- 保留批次操作（CacheServiceInterface 獨有）與管理操作（CacheManagerInterface 獨有）
+
+**Non-Goals:**
+- 不改變任何現有類別的實作邏輯
+- 不重構 `CacheService` 或 `CacheManager` 的內部實作
+- 不改變 DI 容器繫結或服務名稱
+- 不更改現有測試
+
+## Decisions
+
+### 1. 共用介面命名與位置
+- **決定**: `CacheInterface`，位於 `App\Shared\Cache\Contracts\CacheInterface`
+- **理由**: 與 `CacheManagerInterface` 同 namespace，符合既有結構。`App\Shared\Contracts` 為舊有位置，不適合放置新檔案
+- **替代方案**: 放在 `App\Shared\Contracts` — 但該 namespace 主要為歷史遺留，無需延續
+
+### 2. 統一 `get()` 簽章
+- **決定**: `get(string $key, mixed $default = null): mixed`
+- **理由**: `CacheManagerInterface` 已有 `$default` 參數，且此為 PSR-16 標準簽章。`CacheServiceInterface` 沒有 `$default`，但加入此參數為純新增（向後相容），不影響現有呼叫端
+- **替代方案**: 不加入 `$default` — 會失去統一化的機會
+
+### 3. 統一 `remember()` 簽章
+- **決定**: `remember(string $key, callable $callback, int $ttl = 3600): mixed`
+- **理由**: `CacheManagerInterface` 使用 `int $ttl = 3600`，`CacheServiceInterface` 使用 `?int $ttl = null`。採用 `int $ttl = 3600` 因為所有底層實作最終都需要一個明確的 TTL 值；`null` 語意模糊
+- **⚠️ 實作類別 `CacheService` 需更新簽章（`?int $ttl = null` → `int $ttl = 3600`），但其所有現有呼叫端均未傳入 `null`，故無需修改
+
+### 4. 繼承方向
+- **決定**: 兩者皆繼承 `CacheInterface`，非其中一個繼承另一個
+- **理由**: `CacheServiceInterface` 與 `CacheManagerInterface` 職責正交（服務 vs 管理），無合理繼承關係。共同點僅為核心快取操作，適合提取為扁平父介面
+- **替代方案**:
+  - A: `CacheManagerInterface extends CacheServiceInterface` — 不合理，管理操作與批次操作無關
+  - C: 直接合併為單一介面 — 違反介面隔離原則（ISP），強迫服務端依賴管理方法
+
+### 5. 兩個繼承介面保留各自獨有方法
+- 無需將批次操作或管理操作提升至 `CacheInterface`
+- `CacheInterface` 保持精簡（7 個方法），符合最小知識原則
+
+## Risks / Trade-offs
+
+| 風險 | 影響 | 緩解措施 |
+|------|------|----------|
+| `remember()` 的 `?int` → `int` 變更影響實作類別 | `CacheService` 需更新簽章與實作 | 編譯時即可發現錯誤；影響範圍僅 1 個類別 |
+| `get()` 加入 `$default` 參數需同步實作類別 | `CacheService` 的 `get()` 簽章與實作邏輯需更新 | 加入選擇性參數為向後相容；回傳值改為 `$default` 而非硬編碼 `null` |
+| 雙 namespace 導致 `use` 陳述混淆 | 開發者需注意 `CacheInterface` 來自新位置 | 新檔案位於 `Cache\Contracts` 子 namespace，命名清晰 |
+| 現有 mock/stub 無需更新 | 因 PHP 介面繼承為向後相容，`createMock()` 與 `Mockery::mock()` 自動處理繼承方法 | 無需額外操作 |
+
+## Migration Plan
+
+1. 建立 `CacheInterface`，定義 7 個核心方法
+2. 修改 `CacheServiceInterface` — `extends CacheInterface`，移除重複方法
+3. **同步更新 `CacheService` 實作類別**：
+   - `get(string $key): mixed` → `get(string $key, mixed $default = null): mixed`（回傳值改為 `$default`）
+   - `remember(string $key, callable $callback, ?int $ttl = null): mixed` → `remember(string $key, callable $callback, int $ttl = 3600): mixed`（移除 `?:` 回退邏輯）
+4. 修改 `CacheManagerInterface` — `extends CacheInterface`，移除重複方法
+   - `CacheManager` 與 `PrefixedCacheManager` 簽章已相容，無需修改
+5. 執行 `composer check-all` 驗證全部通過
+
+## Open Questions
+
+- 是否有任何程式碼直接將 `CacheServiceInterface` 與 `CacheManagerInterface` 互相比較或型別判斷？（可能性極低，但需確認）

--- a/openspec/changes/cache-interface-unification/proposal.md
+++ b/openspec/changes/cache-interface-unification/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+AlleyNote 目前有兩個快取介面 — `CacheServiceInterface`（10 個方法、22 個呼叫端）與 `CacheManagerInterface`（16 個方法、7 個呼叫端）— 各自獨立定義了 get/set/has/delete/clear/remember/getStats 等核心方法，但簽章細節略有差異。這種重複造成維護負擔：核心行為修改需同步兩處，新功能（如批次操作）若只加在其中一個介面會導致功能缺口。提取共用的父介面可消除重複、統一契約，並為後續快取層演進建立一致性基礎。
+
+## What Changes
+
+- 新增 `CacheInterface` 作為共用父介面，包含兩者皆有的核心方法，並統一方法簽章
+- `CacheServiceInterface` 改為繼承 `CacheInterface`，保留 `getMultiple`、`setMultiple`、`deleteMultiple`、`deletePattern` 等批次操作方法
+- `CacheManagerInterface` 改為繼承 `CacheInterface`，保留 `tags`、`prefix`、`driver`、`getHealthStatus`、`warmup`、`cleanup`、`getDriver`、`getDrivers` 等管理操作方法
+- `CacheService` 實作類別需配合更新 `get()` 與 `remember()` 方法簽章（其餘所有呼叫端無需修改，非破壞性變更）
+
+## Capabilities
+
+### New Capabilities
+- `cache-interface-core`: 新 `CacheInterface`，定義 get/set/has/delete/clear/remember/getStats 共 7 個核心方法，統一 `get()` 與 `remember()` 簽章
+- `cache-service-interface-migration`: 將 `CacheServiceInterface` 改為繼承 `CacheInterface`，移除重複的核心方法定義
+- `cache-manager-interface-migration`: 將 `CacheManagerInterface` 改為繼承 `CacheInterface`，移除重複的核心方法定義
+
+### Modified Capabilities
+<!-- 無既有規格受影響 -->
+
+## Impact
+
+- 受影響檔案：
+  - 新增：`backend/app/Shared/Cache/Contracts/CacheInterface.php`
+  - 修改：`CacheServiceInterface.php`、`CacheManagerInterface.php`
+  - 潛在影響：29 個直接介面實作與呼叫端（含 1 個實作類別需更新簽章，其餘 28 個純 type-hint 呼叫端無需修改）
+- 無資料庫變更、無路由變更、無前端變更
+- 非破壞性向後相容

--- a/openspec/changes/cache-interface-unification/specs/cache-interface-core/spec.md
+++ b/openspec/changes/cache-interface-unification/specs/cache-interface-core/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: 定義 CacheInterface 核心方法
+
+新 `CacheInterface` SHALL 定義以下 7 個核心快取操作方法，作為 `CacheServiceInterface` 與 `CacheManagerInterface` 的共用父介面。
+
+#### Scenario: get 方法簽章
+- **WHEN** 呼叫端調用 `get(string $key, mixed $default = null): mixed`
+- **THEN** 系統 SHALL 回傳指定鍵的快取值，若不存在則回傳 `$default`
+
+#### Scenario: set 方法簽章
+- **WHEN** 呼叫端調用 `set(string $key, mixed $value, int $ttl = 3600): bool`
+- **THEN** 系統 SHALL 將資料存入快取，回傳是否成功
+
+#### Scenario: has 方法簽章
+- **WHEN** 呼叫端調用 `has(string $key): bool`
+- **THEN** 系統 SHALL 回傳指定鍵是否存在
+
+#### Scenario: delete 方法簽章
+- **WHEN** 呼叫端調用 `delete(string $key): bool`
+- **THEN** 系統 SHALL 刪除指定鍵的快取，回傳是否成功
+
+#### Scenario: clear 方法簽章
+- **WHEN** 呼叫端調用 `clear(): bool`
+- **THEN** 系統 SHALL 清空所有快取，回傳是否成功
+
+#### Scenario: remember 方法簽章
+- **WHEN** 呼叫端調用 `remember(string $key, callable $callback, int $ttl = 3600): mixed`
+- **THEN** 系統 SHALL 回傳快取值；若不存在則執行回調、快取結果後回傳
+
+#### Scenario: getStats 方法簽章
+- **WHEN** 呼叫端調用 `getStats(): array`
+- **THEN** 系統 SHALL 回傳包含命中率與快取數量的統計陣列
+
+### Requirement: 介面位置與 namespace
+
+`CacheInterface` SHALL 位於 `App\Shared\Cache\Contracts\CacheInterface`。
+
+#### Scenario: 正確 namespace
+- **WHEN** 載入 `CacheInterface`
+- **THEN** 其完整類別名稱 SHALL 為 `App\Shared\Cache\Contracts\CacheInterface`

--- a/openspec/changes/cache-interface-unification/specs/cache-manager-interface-migration/spec.md
+++ b/openspec/changes/cache-interface-unification/specs/cache-manager-interface-migration/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: CacheManagerInterface 繼承 CacheInterface
+
+`CacheManagerInterface` SHALL `extends CacheInterface`，並移除 `CacheInterface` 中已定義的 7 個核心方法（get、set、has、delete、clear、remember、getStats）。
+
+#### Scenario: 繼承關係正確
+- **WHEN** 檢查 `CacheManagerInterface` 定義
+- **THEN** 其 SHALL `extends \App\Shared\Cache\Contracts\CacheInterface`
+
+#### Scenario: 重複方法已移除
+- **WHEN** 檢查 `CacheManagerInterface` 的方法清單
+- **THEN** `get`、`set`、`has`、`delete`、`clear`、`remember`、`getStats` SHALL 不存在於此介面中
+
+#### Scenario: 獨有方法保留
+- **WHEN** 檢查 `CacheManagerInterface`
+- **THEN** `tags`、`prefix`、`driver`、`getHealthStatus`、`warmup`、`cleanup`、`getDriver`、`getDrivers` SHALL 仍然保留
+
+### Requirement: 向後相容
+
+所有現有實作 `CacheManagerInterface` 的類別 SHALL 不需修改即可繼續運作。
+
+#### Scenario: 現有實作無需變更
+- **WHEN** PHP 編譯器檢查實作 `CacheManagerInterface` 的類別
+- **THEN** 所有現有實作 SHALL 通過型別檢查，不需新增任何方法
+
+#### Scenario: 現有呼叫端不受影響
+- **WHEN** 檢查所有 `CacheManagerInterface` 的 type hint 用法
+- **THEN** 所有使用 `CacheManagerInterface` 作為型別的參數、屬性、回傳值 SHALL 維持不變

--- a/openspec/changes/cache-interface-unification/specs/cache-service-interface-migration/spec.md
+++ b/openspec/changes/cache-interface-unification/specs/cache-service-interface-migration/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: CacheServiceInterface 繼承 CacheInterface
+
+`CacheServiceInterface` SHALL `extends CacheInterface`，並移除 `CacheInterface` 中已定義的 7 個核心方法（get、set、has、delete、clear、remember、getStats）。
+
+#### Scenario: 繼承關係正確
+- **WHEN** 檢查 `CacheServiceInterface` 定義
+- **THEN** 其 SHALL `extends \App\Shared\Cache\Contracts\CacheInterface`
+
+#### Scenario: 重複方法已移除
+- **WHEN** 檢查 `CacheServiceInterface` 的方法清單
+- **THEN** `get`、`set`、`has`、`delete`、`clear`、`remember`、`getStats` SHALL 不存在於此介面中
+
+#### Scenario: 獨有方法保留
+- **WHEN** 檢查 `CacheServiceInterface`
+- **THEN** `getMultiple`、`setMultiple`、`deleteMultiple`、`deletePattern` SHALL 仍然保留
+
+### Requirement: 向後相容
+
+所有 `CacheServiceInterface` 的呼叫端 SHALL 不需修改即可繼續運作。
+實作類別 `CacheService` SHALL 更新其 `get()` 與 `remember()` 簽章以匹配 `CacheInterface`。
+
+#### Scenario: CacheService 簽章相容
+- **WHEN** PHP 編譯器檢查 `CacheService`
+- **THEN** `CacheService` 的 `get()` SHALL 加入 `$default = null` 參數；`remember()` SHALL 改為 `int $ttl = 3600`
+- **AND** 既有呼叫端因未傳入 `$default` 或 `null` TTL，行為完全不受影響
+
+#### Scenario: 現有呼叫端不受影響
+- **WHEN** 檢查所有 `CacheServiceInterface` 的 type hint 用
+- **THEN** 所有使用 `CacheServiceInterface` 作為型別的參數、屬性、回傳值 SHALL 維持不變

--- a/openspec/changes/cache-interface-unification/tasks.md
+++ b/openspec/changes/cache-interface-unification/tasks.md
@@ -1,0 +1,26 @@
+## 1. 建立共用 CacheInterface
+
+- [ ] 1.1 在 `backend/app/Shared/Cache/Contracts/` 建立 `CacheInterface.php`，定義 7 個核心方法（get/set/has/delete/clear/remember/getStats），方法簽章依設計決定
+- [ ] 1.2 確認 `CacheInterface` 方法簽章與兩現有介面相容：`get()` 含 `$default = null`，`remember()` 使用 `int $ttl = 3600`
+
+## 2. 遷移 CacheServiceInterface
+
+- [ ] 2.1 修改 `CacheServiceInterface`：加入 `extends \App\Shared\Cache\Contracts\CacheInterface`
+- [ ] 2.2 從 `CacheServiceInterface` 移除 7 個核心方法（get/set/has/delete/clear/remember/getStats）
+- [ ] 2.3 確認保留的獨有方法（getMultiple/setMultiple/deleteMultiple/deletePattern）簽章不變
+- [ ] 2.4 同步更新 `CacheService` 實作類別：
+  - `get()` 加入 `$default = null` 參數，回傳值從 `null` 改為 `$default`
+  - `remember()` 改為 `?int $ttl = null` → `int $ttl = 3600`，內部 `$ttl ?: self::TTL` 改為 `$ttl`
+
+## 3. 遷移 CacheManagerInterface
+
+- [ ] 3.1 修改 `CacheManagerInterface`：加入 `extends \App\Shared\Cache\Contracts\CacheInterface`
+- [ ] 3.2 從 `CacheManagerInterface` 移除 7 個核心方法（get/set/has/delete/clear/remember/getStats）
+- [ ] 3.3 確認保留的獨有方法（tags/prefix/driver/getHealthStatus/warmup/cleanup/getDriver/getDrivers）簽章不變
+
+## 4. 驗證與測試
+
+- [ ] 4.1 執行 `composer analyse`（PHPStan Level 10）確認無型別錯誤
+- [ ] 4.2 執行 `composer cs-check` 確認符合程式碼風格
+- [ ] 4.3 執行 `composer test` 確認所有單元與整合測試通過
+- [ ] 4.4 手動確認所有使用 `CacheServiceInterface` 或 `CacheManagerInterface` 作為 type hint 的 29 個呼叫端無需修改（不含實作類別）


### PR DESCRIPTION
## 變更摘要
- 本次 PR 變更以下模組：backend, openspec
- 涵蓋 commit：
  - refactor: 萃取 CacheInterface 統一快取介面階層

## 主要變更項目
- **backend/app/Infrastructure/Services**：修改 `CacheService.php`
- **backend/app/Shared/Cache/Contracts**：新增 `CacheInterface.php`
- **backend/app/Shared/Cache/Contracts**：修改 `CacheManagerInterface.php`
- **backend/app/Shared/Contracts**：修改 `CacheServiceInterface.php`
- **openspec/changes/cache-interface-unification**：新增 `.openspec.yaml`
- **openspec/changes/cache-interface-unification**：新增 `design.md`
- **openspec/changes/cache-interface-unification**：新增 `proposal.md`
- **openspec/changes/cache-interface-unification/specs/cache-interface-core**：新增 `spec.md`
- **openspec/changes/cache-interface-unification/specs/cache-manager-interface-migration**：新增 `spec.md`
- **openspec/changes/cache-interface-unification/specs/cache-service-interface-migration**：新增 `spec.md`
- **openspec/changes/cache-interface-unification**：新增 `tasks.md`

## 測試與驗證
- [ ] 單元測試
- [ ] 整合測試
- [ ] 手動驗證
- [ ] 靜態檢查（Lint/型別檢查）

測試細節：
- 指令：執行相關測試套件（如 npm test、pytest、cargo test 等）
- 結果：所有測試通過

## 風險與回滾
- 潛在風險：低風險，本次變更不影響核心功能
- 監控指標：無需額外監控
- 回滾方式：git revert HEAD

## 相關議題
- 無相關 Issue
