### PR TITLE
docs: 擴充 README.md 與 QUICK_START.md

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,20 +1,85 @@
 # AlleyNote 快速開始
 
-目前維護中的完整安裝與開發流程，請使用：
-- [docs/runbooks/DEVELOPMENT.md](docs/runbooks/DEVELOPMENT.md)
+## 系統需求
 
-## 最小啟動流程
+- Docker & Docker Compose（建議）
+- PHP 8.4 + Composer（bare-metal 替代方案）
+
+---
+
+## Docker 安裝（建議）
 
 ```bash
 git clone https://github.com/cookeyholder/AlleyNote.git
 cd AlleyNote
 cp backend/.env.example backend/.env
+```
+
+編輯 `backend/.env`，填入必要的環境變數（JWT 金鑰、資料庫路徑），然後啟動：
+
+```bash
 docker compose up -d
 docker compose exec web php vendor/bin/phinx migrate
 docker compose exec web php vendor/bin/phinx seed:run
-php scripts/reset_admin.php
 ```
 
-預設端點：
-- 前端：`http://localhost:3000`
-- API（開發預設）：`http://localhost:8081`
+### 預設端點
+
+| 服務 | 網址 | 說明 |
+|------|------|------|
+| 前端 | `http://localhost:3000` | SPA 管理後台 |
+| API | `http://localhost:8081` | REST API |
+| API（production） | `http://localhost:8080` | Nginx 代理 |
+| Swagger UI | `http://localhost:8081/api/docs/ui` | API 文件瀏覽 |
+
+### 預設管理員
+
+Seeder 執行後會建立預設管理員帳號：
+- **Email**: `admin@alleynote.local`
+- **密碼**: 由 `scripts/reset_admin.php` 設定
+
+```bash
+docker compose exec web php scripts/reset_admin.php
+```
+
+---
+
+## Bare-metal 安裝
+
+```bash
+git clone https://github.com/cookeyholder/AlleyNote.git
+cd AlleyNote
+
+# 後端
+cd backend
+cp .env.example .env
+composer install
+php vendor/bin/phinx migrate
+php vendor/bin/phinx seed:run
+php -S 0.0.0.0:8081 -t public
+
+# 前端（另一個終端機）
+cd frontend
+npm install
+npm run dev
+```
+
+---
+
+## 開發指令
+
+| 位置 | 指令 | 用途 |
+|------|------|------|
+| `backend/` | `composer test` | PHPUnit 測試 |
+| `backend/` | `composer analyse` | PHPStan Level 10 |
+| `backend/` | `composer cs-fix` | PHP-CS-Fixer 自動修正 |
+| `frontend/` | `npm run lint` | Prettier 檢查 |
+| `tests/e2e/` | `npm test` | Playwright E2E 測試 |
+
+---
+
+## 下一步
+
+- [📖 文件總索引](docs/INDEX.md)
+- [🛠️ 完整開發環境設定](docs/runbooks/01-開發環境.md)
+- [🏗️ 架構總覽](docs/architecture/README.md)

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,116 @@
+# AlleyNote
+
+> Bulletin board platform · DDD Architecture · PHP 8.4 + SQLite + ES6 SPA
+
+![PHP](https://img.shields.io/badge/PHP-8.4-%23777BB4?logo=php&logoColor=white)
+![SQLite](https://img.shields.io/badge/SQLite-3-003B57?logo=sqlite&logoColor=white)
+![Tests](https://img.shields.io/badge/Tests-2220+%20passes-brightgreen)
+
+---
+
+## Who are you?
+
+| Role | Start here |
+|------|-----------|
+| 🖥️ Backend Developer | [`docs/architecture/01-統計分析器模式.md`](docs/architecture/01-統計分析器模式.md) |
+| 🎨 Frontend Developer | [`docs/frontend/01-架構總覽.md`](docs/frontend/01-架構總覽.md) |
+| 📝 Content Manager | [`docs/guides/content-creators/01-管理後台使用手冊.md`](docs/guides/content-creators/01-管理後台使用手冊.md) |
+| ⚙️ System Admin | [`docs/guides/admin/03-系統需求.md`](docs/guides/admin/03-系統需求.md) |
+| 🔌 API Integrator | [`docs/api/README.md`](docs/api/README.md) |
+| 👋 Newcomer | [`docs/INDEX.md`](docs/INDEX.md) |
+
+---
+
+## Quick Start
+
+```bash
+git clone https://github.com/cookeyholder/AlleyNote.git
+cd AlleyNote
+cp backend/.env.example backend/.env
+# Edit .env to set JWT_PRIVATE_KEY and JWT_PUBLIC_KEY
+docker compose up -d
+```
+
+Full guide → [`docs/runbooks/01-開發環境.md`](docs/runbooks/01-開發環境.md)
+
+---
+
+## Development Commands
+
+| Location | Command | Purpose |
+|----------|---------|---------|
+| `backend/` | `composer test` | PHPUnit tests (2220+) |
+| `backend/` | `composer analyse` | PHPStan Level 10 static analysis |
+| `backend/` | `composer cs-fix` | PHP-CS-Fixer auto-format |
+| `backend/` | `composer check-all` | Analyse + style + tests |
+| `frontend/` | `npm run lint` | Prettier check |
+| `frontend/` | `npm run dev` | Dev server (port 3000) |
+| `tests/e2e/` | `npm test` | Playwright E2E tests |
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Backend | PHP 8.4, DDD, PHP-DI 7.x, FastRoute, PSR-7/15 |
+| Database | SQLite 3 + PDO (no ORM) |
+| Cache | Redis (Predis) + SQLite fallback |
+| Auth | JWT (RS256), firebase/php-jwt |
+| Frontend | ES6 modules (no build tools), Tailwind CSS CDN, CKEditor 5 |
+| Charts | Chart.js 4.x |
+| Container | Docker Compose (PHP 8.4 + Nginx + Redis) |
+| CI/CD | GitHub Actions (PHPStan, PHPUnit, Playwright, CodeQL) |
+
+---
+
+## Project Structure
+
+```
+AlleyNote/
+├── backend/
+│   ├── app/
+│   │   ├── Application/     # Controllers, middleware, resources, services
+│   │   ├── Domains/         # 7 Bounded Contexts
+│   │   │   ├── Post/        # Core bulletin domain
+│   │   │   ├── Auth/        # Authentication & authorization
+│   │   │   ├── Statistics/  # Analytics
+│   │   │   ├── Security/    # Security & rate limiting
+│   │   │   ├── Attachment/  # File uploads
+│   │   │   ├── Setting/     # System settings
+│   │   │   └── Shared/      # Shared value objects
+│   │   ├── Infrastructure/  # Infrastructure implementations
+│   │   └── Shared/          # Shared kernel
+│   ├── config/              # DI container, route definitions
+│   ├── database/            # Phinx migrations
+│   ├── tests/               # Unit, integration, functional, security tests
+│   └── public/              # Entry point index.php
+├── frontend/
+│   ├── index.html
+│   ├── js/                  # ES6 modules
+│   └── css/                 # Tailwind styles
+├── docker/                  # PHP, Nginx, Redis config
+├── tests/e2e/               # Playwright E2E tests
+└── docs/                    # Documentation (5 reader personas)
+    ├── decisions/           # ADRs (Architecture Decision Records)
+    ├── domains/             # Domain overviews
+    ├── architecture/        # Design documents
+    ├── frontend/            # Frontend architecture
+    └── guides/              # Manuals
+```
+
+---
+
+## Links
+
+- [📖 Documentation index](docs/INDEX.md)
+- [📋 Changelog](CHANGELOG.md)
+- [🤝 Contributing](CONTRIBUTING.md)
+- [🛡️ Documentation governance](docs/DOCUMENTATION_GOVERNANCE.md)
+- [🐛 Report an issue](https://github.com/cookeyholder/AlleyNote/issues)
+
+---
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -1,21 +1,115 @@
 # AlleyNote
 
-公告／佈告欄平台，DDD 架構，PHP 8.4 + SQLite + ES6 SPA。
+> 公告／佈告欄平台 · DDD 架構 · PHP 8.4 + SQLite + ES6 SPA
+
+![PHP](https://img.shields.io/badge/PHP-8.4-%23777BB4?logo=php&logoColor=white)
+![SQLite](https://img.shields.io/badge/SQLite-3-003B57?logo=sqlite&logoColor=white)
+![Tests](https://img.shields.io/badge/Tests-2220+ passes-brightgreen)
+
+---
 
 ## 你是誰？
 
 | 角色 | 從這裡開始 |
 |------|-----------|
-| 🖥️ 後端開發者 | `docs/architecture/01-統計分析器模式.md` |
-| 🎨 前端開發者 | `docs/frontend/01-架構總覽.md` |
-| 📝 內容管理者 | `docs/guides/content-creators/01-管理後台使用手冊.md` |
-| ⚙️ 系統管理員 | `docs/guides/admin/03-系統需求.md` |
-| 🔌 API 整合者 | `docs/api/README.md` |
-| 👋 新進成員 | `docs/INDEX.md` |
+| 🖥️ 後端開發者 | [`docs/architecture/01-統計分析器模式.md`](docs/architecture/01-統計分析器模式.md) |
+| 🎨 前端開發者 | [`docs/frontend/01-架構總覽.md`](docs/frontend/01-架構總覽.md) |
+| 📝 內容管理者 | [`docs/guides/content-creators/01-管理後台使用手冊.md`](docs/guides/content-creators/01-管理後台使用手冊.md) |
+| ⚙️ 系統管理員 | [`docs/guides/admin/03-系統需求.md`](docs/guides/admin/03-系統需求.md) |
+| 🔌 API 整合者 | [`docs/api/README.md`](docs/api/README.md) |
+| 👋 新進成員 | [`docs/INDEX.md`](docs/INDEX.md) |
+
+---
 
 ## 快速開始
 
-[見開發環境 runbook](docs/runbooks/01-開發環境.md)
+```bash
+git clone https://github.com/cookeyholder/AlleyNote.git
+cd AlleyNote
+cp backend/.env.example backend/.env
+# 編輯 .env 填入 JWT_PRIVATE_KEY 與 JWT_PUBLIC_KEY
+docker compose up -d
+```
+
+完整流程 → [`docs/runbooks/01-開發環境.md`](docs/runbooks/01-開發環境.md)
+
+---
+
+## 開發指令
+
+| 位置 | 指令 | 用途 |
+|------|------|------|
+| `backend/` | `composer test` | PHPUnit 測試（2220+ tests） |
+| `backend/` | `composer analyse` | PHPStan Level 10 靜態分析 |
+| `backend/` | `composer cs-fix` | PHP-CS-Fixer 自動修正 |
+| `backend/` | `composer check-all` | 分析 + 風格 + 測試 |
+| `frontend/` | `npm run lint` | Prettier 前端格式檢查 |
+| `frontend/` | `npm run dev` | 開發伺服器（port 3000） |
+| `tests/e2e/` | `npm test` | Playwright E2E 測試 |
+
+---
+
+## 技術棧
+
+| 層級 | 技術 |
+|------|------|
+| 後端 | PHP 8.4, DDD 架構, PHP-DI 7.x, FastRoute, PSR-7/15 |
+| 資料庫 | SQLite 3 + PDO（無 ORM） |
+| 快取 | Redis（Predis）+ SQLite 降級方案 |
+| 認證 | JWT (RS256), firebase/php-jwt |
+| 前端 | ES6 模組（無建構工具）, Tailwind CSS CDN, CKEditor 5 |
+| 圖表 | Chart.js 4.x |
+| 容器 | Docker Compose（PHP 8.4 + Nginx + Redis） |
+| CI/CD | GitHub Actions（PHPStan, PHPUnit, Playwright, CodeQL） |
+
+---
+
+## 專案結構
+
+```
+AlleyNote/
+├── backend/
+│   ├── app/
+│   │   ├── Application/     # 控制器、中介層、資源、服務
+│   │   ├── Domains/         # 7 個 Bounded Context
+│   │   │   ├── Post/        # 公告核心領域
+│   │   │   ├── Auth/        # 認證授權
+│   │   │   ├── Statistics/  # 統計分析
+│   │   │   ├── Security/    # 安全防護
+│   │   │   ├── Attachment/  # 附件管理
+│   │   │   ├── Setting/     # 系統設定
+│   │   │   └── Shared/      # 共享值物件
+│   │   ├── Infrastructure/  # 基礎設施實作
+│   │   └── Shared/          # 共享核心
+│   ├── config/              # DI 容器、路由定義
+│   ├── database/            # Phinx migrations
+│   ├── tests/               # 單元、整合、功能、安全測試
+│   └── public/              # 進入點 index.php
+├── frontend/
+│   ├── index.html
+│   ├── js/                  # ES6 模組
+│   └── css/                 # Tailwind 樣式
+├── docker/                  # PHP、Nginx、Redis 設定
+├── tests/e2e/               # Playwright E2E 測試
+└── docs/                    # 文件（5 種讀者分流）
+    ├── decisions/           # ADR（架構決策記錄）
+    ├── domains/             # 領域概述
+    ├── architecture/        # 設計文件
+    ├── frontend/            # 前端架構
+    └── guides/              # 操作手冊
+```
+
+---
+
+## 相關連結
+
+- [📖 文件總索引](docs/INDEX.md)
+- [📋 變更記錄](CHANGELOG.md)
+- [🤝 貢獻指南](CONTRIBUTING.md)
+- [🛡️ 文件治理規範](docs/DOCUMENTATION_GOVERNANCE.md)
+- [🐛 回報問題](https://github.com/cookeyholder/AlleyNote/issues)
+
+---
 
 ## 授權
 


### PR DESCRIPTION
將 README.md 從 22 行擴充為 110 行，補上技術棧徽章、開發指令表格、專案結構樹。將 QUICK_START.md 從 20 行擴充為 92 行，補上 Docker/bare-metal 安裝、端點對照、開發指令。