### PR TITLE
fix: 以動態 CI 徽章取代靜態 Tests 徽章

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -4,7 +4,7 @@
 
 ![PHP](https://img.shields.io/badge/PHP-8.4-%23777BB4?logo=php&logoColor=white)
 ![SQLite](https://img.shields.io/badge/SQLite-3-003B57?logo=sqlite&logoColor=white)
-![Tests](https://img.shields.io/badge/Tests-2220+%20passes-brightgreen)
+[![CI](https://github.com/cookeyholder/AlleyNote/actions/workflows/ci.yml/badge.svg)](https://github.com/cookeyholder/AlleyNote/actions/workflows/ci.yml)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![PHP](https://img.shields.io/badge/PHP-8.4-%23777BB4?logo=php&logoColor=white)
 ![SQLite](https://img.shields.io/badge/SQLite-3-003B57?logo=sqlite&logoColor=white)
-![Tests](https://img.shields.io/badge/Tests-2220+ passes-brightgreen)
+[![CI](https://github.com/cookeyholder/AlleyNote/actions/workflows/ci.yml/badge.svg)](https://github.com/cookeyholder/AlleyNote/actions/workflows/ci.yml)
 
 ---
 


### PR DESCRIPTION
README.md 和 README.en.md 中原有的 Tests 徽章是靜態圖片，永遠顯示 2220+ passes，與實際 CI 結果脫節。改用 GitHub Actions 的動態 CI 徽章，點擊可直達 Actions 頁面。