### PR TITLE
fix(security): 合併 4 個依賴安全升級至單一 PR

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -22,7 +22,7 @@
         "zircote/swagger-php": "^6.1.2",
         "ramsey/uuid": "^4.0",
         "ezyang/htmlpurifier": "^4.16",
-        "guzzlehttp/guzzle": "^7.0",
+        "guzzlehttp/guzzle": "^7.15.1",
         "predis/predis": "^3.4"
     },
     "require-dev": {

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1966c2f9a04d866a0876afbae844cf3a",
+    "content-hash": "eb5e687f56e81adef56dee3c0acaa927",
     "packages": [
         {
             "name": "brick/math",
@@ -580,22 +580,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.14.2",
+            "version": "7.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "fa88c57803501ad0770f5cddb1e60525d49da9a1"
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/fa88c57803501ad0770f5cddb1e60525d49da9a1",
-                "reference": "fa88c57803501ad0770f5cddb1e60525d49da9a1",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^2.5.1",
-                "guzzlehttp/psr7": "^2.12.5",
+                "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -608,7 +608,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.3",
-                "guzzlehttp/test-server": "^0.6",
+                "guzzlehttp/test-server": "^0.7",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -688,7 +688,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.14.2"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
             },
             "funding": [
                 {
@@ -704,7 +704,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-14T18:15:01+00:00"
+            "time": "2026-07-26T23:23:20+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -792,16 +792,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.5",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "9365d578a9fd1552ad6ca9c3cb530708526feb09"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9365d578a9fd1552ad6ca9c3cb530708526feb09",
-                "reference": "9365d578a9fd1552ad6ca9c3cb530708526feb09",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
@@ -891,7 +891,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.5"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -907,7 +907,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-13T01:27:20+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
         },
         {
             "name": "laravel/serializable-closure",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,29 +1,29 @@
 {
-  "name": "app",
+  "name": "AlleyNote",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "devDependencies": {
-        "@playwright/test": "^1.61.1",
-        "playwright": "^1.61.1",
-        "prettier": "^3.9.4"
+        "@playwright/test": "^1.62.0",
+        "playwright": "^1.62.0",
+        "prettier": "^3.9.6"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/fsevents": {
@@ -42,41 +42,41 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
-      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "lint:fix": "prettier --write \"frontend/js/**/*.js\" \"frontend/*.html\" \"tests/e2e/tests/**/*.js\""
   },
   "devDependencies": {
-    "@playwright/test": "^1.61.1",
-    "playwright": "^1.61.1",
-    "prettier": "^3.9.4"
+    "@playwright/test": "^1.62.0",
+    "playwright": "^1.62.0",
+    "prettier": "^3.9.6"
   }
 }


### PR DESCRIPTION
## 變更摘要

合併 4 個待處理的 Dependabot 安全性/依賴更新 PR（#134、#135、#136、#137）至單一 PR，一次解決所有 Dependabot 回報的問題。

## 升級項目

### 後端（PHP）

| 套件 | 舊版本 | 新版本 | 原因 |
|------|--------|--------|------|
| guzzlehttp/guzzle | 7.14.2 | 7.15.2 | 修復 3 個 medium severity 漏洞（#134） |
| guzzlehttp/psr7 | 2.12.5 | 2.13.0 | guzzle 相依套件同步升級 |

**guzzle 修復的安全漏洞**（對應 Dependabot alert #37/#38/#39）：

- **URI fragments disclosed in redirect Referer headers**（CVSS 5.9）
- **Unbounded response cookies risk denial of service**（CVSS 5.3）
- **Host-only cookie scope is not preserved**（CVSS 5.9）

### 前端 / E2E（npm）

| 套件 | 舊版本（package.json） | lockfile 解析版本 | 來源 PR |
|------|------------------------|-------------------|---------|
| prettier | ^3.9.4 | 3.9.6 | #135 |
| playwright | ^1.61.1 | 1.62.1 | #136 |
| @playwright/test | ^1.61.1 | 1.62.1 | #137 |

> 註：`^1.62.0` 允許自動解析至 1.62.1（patch 版本），lockfile 已鎖定實際解析結果。

## 測試與驗證

- [x] `composer validate` 通過
- [x] `composer audit` 無安全性漏洞
- [x] PHPUnit：2328 tests / 9316 assertions 全數通過
- [x] Prettier check 通過（frontend + tests/e2e）
- [x] `npm install` 0 vulnerabilities
- [x] CI：Analyze（3 語言）、CodeQL、Security Vulnerability Scan、Tests (PHP 8.4)、e2e-tests 全數通過

## 風險與回滾

- **風險等級**: 極低
- **變更範圍**: 僅 `backend/composer.json`、`backend/composer.lock`、`package.json`、`package-lock.json`
- **Breaking Changes**: 無（Guzzle 7.x semver 向後相容；專案僅在 `PwnedPasswordService.php` 使用 Guzzle HTTP Client；Playwright 需 Node >= 20，CI 環境相容）
- **回滾方式**: `git revert HEAD`

## 合併後動作

- 關閉原 4 個 PR：#134、#135、#136、#137（已完成）
