### PR TITLE
fix(statistics): 修復 Linux /proc/meminfo MemAvailable 記憶體重複扣除與 0% 顯示 Bug

### DIFF
--- a/backend/app/Infrastructure/Statistics/Services/SystemMonitoringService.php
+++ b/backend/app/Infrastructure/Statistics/Services/SystemMonitoringService.php
@@ -107,6 +107,7 @@ class SystemMonitoringService implements SystemMonitoringServiceInterface
         $freeMemory = 0;
         $buffers = 0;
         $cached = 0;
+        $hasAvailable = false;
 
         if (is_readable('/proc/meminfo')) {
             $meminfo = file_get_contents('/proc/meminfo');
@@ -114,7 +115,6 @@ class SystemMonitoringService implements SystemMonitoringServiceInterface
                 if (preg_match('/MemTotal:\s+(\d+)\s+kB/i', $meminfo, $matches)) {
                     $totalMemory = (int) $matches[1] * 1024;
                 }
-                $hasAvailable = false;
                 if (preg_match('/MemAvailable:\s+(\d+)\s+kB/i', $meminfo, $matches)) {
                     $freeMemory = (int) $matches[1] * 1024;
                     $hasAvailable = true;
@@ -127,27 +127,25 @@ class SystemMonitoringService implements SystemMonitoringServiceInterface
                 if (preg_match('/^Cached:\s+(\d+)\s+kB/im', $meminfo, $matches)) {
                     $cached = (int) $matches[1] * 1024;
                 }
-                if ($hasAvailable) {
-                    $usedMemory = max(0, $totalMemory - $freeMemory);
-                } else {
-                    $realFree = $freeMemory + $buffers + $cached;
-                    $usedMemory = max(0, $totalMemory - $realFree);
-                }
             }
         }
 
-        if ($totalMemory === 0) {
+        if ($totalMemory > 0) {
+            if ($hasAvailable) {
+                $usedMemory = max(0, $totalMemory - $freeMemory);
+            } else {
+                $realFree = $freeMemory + $buffers + $cached;
+                $usedMemory = max(0, $totalMemory - $realFree);
+            }
+        } else {
             // 回退使用 PHP 記憶體限制與記憶體使用量估算
             $phpLimitStr = ini_get('memory_limit');
             $phpLimit = is_string($phpLimitStr) ? $this->parseSize($phpLimitStr) : 0;
             $totalMemory = $phpLimit > 0 ? $phpLimit : 512 * 1024 * 1024;
             $usedMemory = memory_get_usage(true);
-        } else {
-            $realFree = $freeMemory + $buffers + $cached;
-            $usedMemory = max(0, $totalMemory - $realFree);
         }
 
-        $usagePercent = $totalMemory > 0 ? round(($usedMemory / $totalMemory) * 100, 1) : 0.0;
+        $usagePercent = round(($usedMemory / $totalMemory) * 100, 1);
 
         return [
             'total_bytes'      => $totalMemory,


### PR DESCRIPTION
## 📌 變更摘要 (Summary)

修復後端主機監控服務 `SystemMonitoringService.php` 在解析 Linux `/proc/meminfo` 時，重複將 `Buffers` 與 `Cached` 記憶體累加至已包含可回收記憶體的 `MemAvailable` 數值中，導致計算出來的已用記憶體小於 0 並被修正為 `0` (0%) 的邏輯 Bug。

---

## 🛠️ 變更內容 (Changes Included)

- **`SystemMonitoringService.php` (`getMemoryMetrics`)**:
  - 當 Linux 核心提供 `MemAvailable` 時，正確計算已用記憶體為 `MemTotal - MemAvailable`。
  - 僅在舊版 Linux 核心無 `MemAvailable` 欄位時，才使用 `MemTotal - (MemFree + Buffers + Cached)` 的公式計算。
  - 避免重複加總導致可釋放記憶體總量超越 `MemTotal` 而使記憶體使用率計算結果降為 0%。

---

## 🧪 測試與驗證 (Testing & Verification)

- **API 驗證**: 呼叫 `GET /api/admin/statistics/system`，驗證回應由原本的 `"usage_percent": 0` 恢復為真實主機使用率 `"usage_percent": 37.4%` (4.31 GB / 11.5 GB)。
- **PHPStan 靜態分析**: 執行 Level 10 檢測全數通過 (`[OK] No errors`)。
- **衝突檢查**: 0 Merge Conflicts。
