### PR TITLE
fix(statistics): 移除 afterRender 重複綁定事件，解決自動刷新等通知彈出兩次的問題

### DIFF
--- a/frontend/js/pages/admin/statistics.js
+++ b/frontend/js/pages/admin/statistics.js
@@ -47,7 +47,6 @@ export default class StatisticsPage extends BaseAdminPage {
 
   afterRender() {
     this.initCharts();
-    this.attachEventListeners();
   }
 
   async loadStatistics() {


### PR DESCRIPTION
## 📌 變更摘要 (Summary)

修復「系統統計頁面 (`frontend/js/pages/admin/statistics.js`)」在初始化時，因 `afterRender()` 重複呼叫 `this.attachEventListeners()`，導致所有 DOM 事件監聽器（如自動更新下拉選單、時間範圍按鈕、手動刷新按鈕等）被重複綁定兩次，進而在設定自動刷新時觸發兩次通知彈窗的問題。

---

## 🛠️ 變更內容 (Changes Included)

- **`statistics.js` (`afterRender`)**:
  - 移除 `afterRender()` 內部對 `this.attachEventListeners()` 的多餘呼叫。
  - 因基底類別 `BaseAdminPage.init()` 生命週期已統一呼叫 `this.attachEventListeners()`，此處移除可避免事件被二次綁定。

---

## 🧪 測試與驗證 (Testing & Verification)

- **E2E 測試**: 執行 Playwright 全套 `11-statistics.spec.js` 測試 100% 通過 (10/10 passed)。
- **Prettier 程式碼格式化**: 通過檢測。
- **衝突檢查**: 0 Merge Conflicts。
