### PR TITLE
fix(router): 修復 SPA 路由讓渡機制並於後台側欄新增 Swagger API 文件入口

### DIFF
--- a/frontend/js/layouts/DashboardLayout.js
+++ b/frontend/js/layouts/DashboardLayout.js
@@ -125,6 +125,12 @@ function renderSidebar(user) {
       label: "系統設定",
       icon: `<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>`,
     },
+    {
+      path: "/api/swagger-ui",
+      label: "API 文件 (Swagger)",
+      external: true,
+      icon: `<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>`,
+    },
   ];
 
   const getUserRole = (u) => {
@@ -173,7 +179,7 @@ function renderSidebar(user) {
             return `
             <a
               href="${item.path}"
-              data-navigo
+              ${item.external ? 'target="_blank" rel="noopener noreferrer"' : "data-navigo"}
               class="flex items-center px-4 py-2.5 text-sm font-medium transition-all duration-200 rounded-xl group ${
                 isActive
                   ? "bg-accent-50 text-accent-700"

--- a/frontend/js/utils/router.js
+++ b/frontend/js/utils/router.js
@@ -268,8 +268,17 @@ export async function initRouter() {
     import("../pages/public/errors.js").then((module) => module.render500());
   });
 
-  // 404 頁面
+  // 404 頁面（對後端 API / Swagger / OpenAPI 路由自動讓渡給瀏覽器請求）
   router.notFound(() => {
+    const path = window.location.pathname;
+    if (
+      path.startsWith("/api/") ||
+      path.startsWith("/swagger") ||
+      path.startsWith("/openapi")
+    ) {
+      window.location.href = path + window.location.search;
+      return;
+    }
     import("../pages/public/errors.js").then((module) => module.render404());
   });
 


### PR DESCRIPTION
## 📌 變更摘要 (Summary)

本 PR 包含以下前端 SPA 路由讓渡與後台 Swagger API 文件選單整合：
1. **修復 SPA 路由攔截 (SPA Router Bypass)**: 修正 `router.js` 中的 404 處置邏輯，讓所有以 `/api/`、`/swagger` 或 `/openapi` 開頭的請求自動讓渡給瀏覽器對後端發起原生 HTTP 請求，解決點擊/訪問 Swagger UI 網頁無反應或被 404 蓋過的問題。
2. **後台側欄新增 Swagger API 文件入口**: 在 `DashboardLayout.js` 的後台選單新增「API 文件 (Swagger)」項目，點擊即可開啟 Swagger 互動式 API 文件。

---

## 🛠️ 變更內容 (Changes Included)

- **`frontend/js/utils/router.js`**:
  - 在 `router.notFound()` 補充 `/api/`、`/swagger`、`/openapi` 前綴跳轉 bypass 邏輯。
- **`frontend/js/layouts/DashboardLayout.js`**:
  - 側欄選單新增「API 文件 (Swagger)」項目，並配置外連 `target="_blank"` 處理。

---

## 🧪 測試與驗證 (Testing & Verification)

- **E2E 測試**: `12-admin-navigation.spec.js` 通過。
- **Prettier 檢查**: 100% 符合規範。
- **衝突檢查**: 0 Merge Conflicts。
