### PR TITLE
fix(openapi): 修復 Swagger UI 因 CSP 標頭封鎖導致空白頁面之問題

### DIFF
--- a/backend/app/Application/Controllers/Web/SwaggerController.php
+++ b/backend/app/Application/Controllers/Web/SwaggerController.php
@@ -97,7 +97,9 @@ class SwaggerController
      */
     public function ui(Request $request, Response $response): Response
     {
-        $html = $this->generateSwaggerUiHtml();
+        $rawNonce = $request->getAttribute('csp_nonce');
+        $nonce = is_string($rawNonce) ? $rawNonce : '';
+        $html = $this->generateSwaggerUiHtml($nonce);
         $response->getBody()->write(($html ?: ''));
 
         return $response
@@ -108,15 +110,17 @@ class SwaggerController
     /**
      * 產生 Swagger UI HTML.
      */
-    private function generateSwaggerUiHtml(): string
+    private function generateSwaggerUiHtml(string $nonce = ''): string
     {
+        $nonceAttr = $nonce !== '' ? ' nonce="' . htmlspecialchars($nonce, ENT_QUOTES, 'UTF-8') . '"' : '';
+
         return <<<HTML
             <!DOCTYPE html>
             <html>
             <head>
                 <title>AlleyNote API Documentation</title>
                 <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5.17.14/swagger-ui.css" />
-                <style>
+                <style{$nonceAttr}>
                     .swagger-ui .topbar { display: none; }
                     .swagger-ui .info { margin: 30px 0; }
                 </style>
@@ -125,7 +129,7 @@ class SwaggerController
                 <div id="swagger-ui"></div>
                 <script src="https://unpkg.com/swagger-ui-dist@5.17.14/swagger-ui-bundle.js"></script>
                 <script src="https://unpkg.com/swagger-ui-dist@5.17.14/swagger-ui-standalone-preset.js"></script>
-                <script>
+                <script{$nonceAttr}>
                 window.onload = function() {
                     SwaggerUIBundle({
                         url: '/api/docs',

--- a/backend/app/Application/Middleware/SecurityHeadersMiddleware.php
+++ b/backend/app/Application/Middleware/SecurityHeadersMiddleware.php
@@ -29,6 +29,11 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
         ServerRequestInterface $request,
         RequestHandlerInterface $handler,
     ): ResponseInterface {
+        if ($this->enabled) {
+            $nonce = $this->headerService->generateNonce();
+            $request = $request->withAttribute('csp_nonce', $nonce);
+        }
+
         $response = $handler->handle($request);
 
         if (!$this->enabled) {

--- a/backend/app/Domains/Security/Services/Headers/SecurityHeaderService.php
+++ b/backend/app/Domains/Security/Services/Headers/SecurityHeaderService.php
@@ -325,8 +325,8 @@ class SecurityHeaderService implements SecurityHeaderServiceInterface
                 'monitoring_endpoint' => null, // 可設定外部監控服務端點
                 'directives'          => [
                     'default-src'               => ["'self'"],
-                    'script-src'                => ["'self'", "'unsafe-inline'", "'unsafe-eval'", 'https://cdn.tailwindcss.com', 'https://cdn.ckeditor.com', 'https://cdn.jsdelivr.net'],
-                    'style-src'                 => ["'self'", "'unsafe-inline'", 'https://cdn.tailwindcss.com', 'https://cdn.ckeditor.com', 'https://fonts.googleapis.com', 'https://cdnjs.cloudflare.com'],
+                    'script-src'                => ["'self'", "'unsafe-inline'", "'unsafe-eval'", 'https://cdn.tailwindcss.com', 'https://cdn.ckeditor.com', 'https://cdn.jsdelivr.net', 'https://unpkg.com'],
+                    'style-src'                 => ["'self'", "'unsafe-inline'", 'https://cdn.tailwindcss.com', 'https://cdn.ckeditor.com', 'https://fonts.googleapis.com', 'https://cdnjs.cloudflare.com', 'https://cdn.jsdelivr.net', 'https://unpkg.com'],
                     'img-src'                   => ["'self'", 'data:', 'blob:', 'https:', 'http:'],
                     'font-src'                  => ["'self'", 'data:', 'https://fonts.gstatic.com', 'https://cdnjs.cloudflare.com', 'https://cdn.ckeditor.com'],
                     'connect-src'               => ["'self'", 'http://localhost:3000', 'http://localhost:8081'],


### PR DESCRIPTION
## 📌 變更摘要 (Summary)

本 PR 修復 Swagger UI 網頁 (`/api/swagger-ui`) 因 CSP 安全標頭封鎖而呈現空白頁面的問題：
1. **CSP 白名單擴充 (unpkg.com)**: 在 `SecurityHeaderService.php` 中將 `https://unpkg.com` 與 `https://cdn.jsdelivr.net` 加入 `script-src` 與 `style-src` 白名單。
2. **CSP Nonce 動態注入**: 在 `SecurityHeadersMiddleware.php` 中將生成的 CSP Nonce 綁定至 Request 屬性，並於 `SwaggerController.php` 產生的 `<style>` 與 `<script>` 標籤注入 `nonce="..."` 屬性，確保 100% 通過瀏覽器 CSP 檢驗並渲染 Swagger 介面。

---

## 🛠️ 變更內容 (Changes Included)

- **`backend/app/Domains/Security/Services/Headers/SecurityHeaderService.php`**:
  - 於 `getDefaultConfig()` 加入 `unpkg.com` 與 `cdn.jsdelivr.net`。
- **`backend/app/Application/Middleware/SecurityHeadersMiddleware.php`**:
  - 將生成的 Nonce 傳遞至 `$request->withAttribute('csp_nonce', $nonce)`。
- **`backend/app/Application/Controllers/Web/SwaggerController.php`**:
  - 在 `ui()` 與 `generateSwaggerUiHtml()` 中使用 `csp_nonce` 設定內嵌腳本與樣式標籤。

---

## 🧪 測試與驗證 (Testing & Verification)

- **API 與 CSP 測試**: `curl` 驗證 `/api/swagger-ui` 正常產出帶有相符 nonce 的 HTML 並且 HTTP Content-Security-Policy 標頭正確包含 `unpkg.com` 與 `nonce`。
- **PHPStan 靜態分析**: Level 10 0 錯誤。
- **PHP CS Fixer 格式檢測**: 100% 符合規範。
- **衝突檢查**: 0 Merge Conflicts。
