### PR TITLE
feat(api): 新增文章 Markdown 匯出端點與站內通知系統端點

### DIFF
--- a/backend/app/Application/Controllers/Api/V1/NotificationController.php
+++ b/backend/app/Application/Controllers/Api/V1/NotificationController.php
@@ -36,8 +36,7 @@ class NotificationController extends BaseController
     public function index(Request $request, Response $response): Response
     {
         try {
-            $user = $request->getAttribute('user');
-            $userId = is_array($user) && isset($user['id']) && is_numeric($user['id']) ? (int) $user['id'] : null;
+            $userId = $this->getUserIdFromRequest($request);
 
             $params = $request->getQueryParams();
             $unreadOnly = !empty($params['unread_only']) && filter_var($params['unread_only'], FILTER_VALIDATE_BOOLEAN);
@@ -78,8 +77,7 @@ class NotificationController extends BaseController
     public function unreadCount(Request $request, Response $response): Response
     {
         try {
-            $user = $request->getAttribute('user');
-            $userId = is_array($user) && isset($user['id']) && is_numeric($user['id']) ? (int) $user['id'] : null;
+            $userId = $this->getUserIdFromRequest($request);
             $count = $this->notificationService->getUnreadCount($userId);
 
             return $this->json($response, [
@@ -114,8 +112,7 @@ class NotificationController extends BaseController
         try {
             $idAttr = $request->getAttribute('id');
             $id = is_numeric($idAttr) ? (int) $idAttr : 0;
-            $user = $request->getAttribute('user');
-            $userId = is_array($user) && isset($user['id']) && is_numeric($user['id']) ? (int) $user['id'] : null;
+            $userId = $this->getUserIdFromRequest($request);
 
             $this->notificationService->markAsRead($id, $userId);
 
@@ -143,8 +140,7 @@ class NotificationController extends BaseController
     public function markAllAsRead(Request $request, Response $response): Response
     {
         try {
-            $user = $request->getAttribute('user');
-            $userId = is_array($user) && isset($user['id']) && is_numeric($user['id']) ? (int) $user['id'] : null;
+            $userId = $this->getUserIdFromRequest($request);
             $count = $this->notificationService->markAllAsRead($userId);
 
             return $this->json($response, [
@@ -208,5 +204,20 @@ class NotificationController extends BaseController
                 'message' => $e->getMessage(),
             ], 400);
         }
+    }
+
+    private function getUserIdFromRequest(Request $request): ?int
+    {
+        $userIdAttr = $request->getAttribute('user_id');
+        if (is_numeric($userIdAttr)) {
+            return (int) $userIdAttr;
+        }
+
+        $userAttr = $request->getAttribute('user');
+        if (is_array($userAttr) && isset($userAttr['id']) && is_numeric($userAttr['id'])) {
+            return (int) $userAttr['id'];
+        }
+
+        return null;
     }
 }

--- a/backend/app/Application/Controllers/Api/V1/NotificationController.php
+++ b/backend/app/Application/Controllers/Api/V1/NotificationController.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Controllers\Api\V1;
+
+use App\Application\Controllers\BaseController;
+use App\Domains\Notification\Contracts\NotificationServiceInterface;
+use App\Domains\Notification\DTOs\CreateNotificationDTO;
+use OpenApi\Attributes as OA;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Throwable;
+
+class NotificationController extends BaseController
+{
+    public function __construct(
+        private readonly NotificationServiceInterface $notificationService,
+    ) {}
+
+    #[OA\Get(
+        path: '/api/notifications',
+        operationId: 'getNotifications',
+        summary: '取得使用者的站內通知列表',
+        tags: ['Notifications'],
+        parameters: [
+            new OA\Parameter(name: 'unread_only', in: 'query', schema: new OA\Schema(type: 'boolean', default: false)),
+            new OA\Parameter(name: 'limit', in: 'query', schema: new OA\Schema(type: 'integer', default: 20)),
+            new OA\Parameter(name: 'offset', in: 'query', schema: new OA\Schema(type: 'integer', default: 0)),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: '成功取得通知列表'),
+            new OA\Response(response: 401, description: '未認證'),
+        ],
+    )]
+    public function index(Request $request, Response $response): Response
+    {
+        try {
+            $user = $request->getAttribute('user');
+            $userId = is_array($user) && isset($user['id']) && is_numeric($user['id']) ? (int) $user['id'] : null;
+
+            $params = $request->getQueryParams();
+            $unreadOnly = !empty($params['unread_only']) && filter_var($params['unread_only'], FILTER_VALIDATE_BOOLEAN);
+            $limitParam = $params['limit'] ?? 20;
+            $offsetParam = $params['offset'] ?? 0;
+            $limit = is_numeric($limitParam) ? max(1, min(100, (int) $limitParam)) : 20;
+            $offset = is_numeric($offsetParam) ? max(0, (int) $offsetParam) : 0;
+
+            $result = $this->notificationService->getUserNotifications($userId, $unreadOnly, $limit, $offset);
+
+            return $this->json($response, [
+                'success' => true,
+                'message' => '取得通知列表成功',
+                'data'    => $result['notifications'],
+                'meta'    => [
+                    'unread_count' => $result['unread_count'],
+                    'limit'        => $result['limit'],
+                    'offset'       => $result['offset'],
+                ],
+            ]);
+        } catch (Throwable $e) {
+            return $this->json($response, [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    #[OA\Get(
+        path: '/api/notifications/unread-count',
+        operationId: 'getUnreadNotificationCount',
+        summary: '取得未讀通知數量',
+        tags: ['Notifications'],
+        responses: [
+            new OA\Response(response: 200, description: '成功取得未讀通知數量'),
+        ],
+    )]
+    public function unreadCount(Request $request, Response $response): Response
+    {
+        try {
+            $user = $request->getAttribute('user');
+            $userId = is_array($user) && isset($user['id']) && is_numeric($user['id']) ? (int) $user['id'] : null;
+            $count = $this->notificationService->getUnreadCount($userId);
+
+            return $this->json($response, [
+                'success' => true,
+                'data'    => [
+                    'unread_count' => $count,
+                ],
+            ]);
+        } catch (Throwable $e) {
+            return $this->json($response, [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    #[OA\Patch(
+        path: '/api/notifications/{id}/read',
+        operationId: 'markNotificationAsRead',
+        summary: '標記單筆通知為已讀',
+        tags: ['Notifications'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: '成功標記為已讀'),
+            new OA\Response(response: 400, description: '標記失敗'),
+        ],
+    )]
+    public function markAsRead(Request $request, Response $response): Response
+    {
+        try {
+            $idAttr = $request->getAttribute('id');
+            $id = is_numeric($idAttr) ? (int) $idAttr : 0;
+            $user = $request->getAttribute('user');
+            $userId = is_array($user) && isset($user['id']) && is_numeric($user['id']) ? (int) $user['id'] : null;
+
+            $this->notificationService->markAsRead($id, $userId);
+
+            return $this->json($response, [
+                'success' => true,
+                'message' => '標記已讀成功',
+            ]);
+        } catch (Throwable $e) {
+            return $this->json($response, [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 400);
+        }
+    }
+
+    #[OA\Patch(
+        path: '/api/notifications/read-all',
+        operationId: 'markAllNotificationsAsRead',
+        summary: '標記所有通知為已讀',
+        tags: ['Notifications'],
+        responses: [
+            new OA\Response(response: 200, description: '成功將所有通知標記為已讀'),
+        ],
+    )]
+    public function markAllAsRead(Request $request, Response $response): Response
+    {
+        try {
+            $user = $request->getAttribute('user');
+            $userId = is_array($user) && isset($user['id']) && is_numeric($user['id']) ? (int) $user['id'] : null;
+            $count = $this->notificationService->markAllAsRead($userId);
+
+            return $this->json($response, [
+                'success' => true,
+                'message' => '所有通知已標記為已讀',
+                'data'    => [
+                    'updated_count' => $count,
+                ],
+            ]);
+        } catch (Throwable $e) {
+            return $this->json($response, [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    #[OA\Post(
+        path: '/api/notifications/broadcast',
+        operationId: 'broadcastNotification',
+        summary: '廣播發送系統通知 (管理員專用)',
+        tags: ['Notifications'],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'title', type: 'string'),
+                    new OA\Property(property: 'message', type: 'string'),
+                    new OA\Property(property: 'type', type: 'string', default: 'system'),
+                    new OA\Property(property: 'user_id', type: 'integer', nullable: true),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: 201, description: '廣播通知成功'),
+            new OA\Response(response: 400, description: '請求資料錯誤'),
+        ],
+    )]
+    public function broadcast(Request $request, Response $response): Response
+    {
+        try {
+            $data = $request->getParsedBody();
+            if (!is_array($data)) {
+                return $this->json($response, [
+                    'success' => false,
+                    'message' => '無效的請求資料',
+                ], 400);
+            }
+
+            $dto = CreateNotificationDTO::fromArray($data);
+            $notification = $this->notificationService->broadcastNotification($dto);
+
+            return $this->json($response, [
+                'success' => true,
+                'message' => '廣播通知發送成功',
+                'data'    => $notification->toArray(),
+            ], 201);
+        } catch (Throwable $e) {
+            return $this->json($response, [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 400);
+        }
+    }
+}

--- a/backend/app/Application/Controllers/Api/V1/PostController.php
+++ b/backend/app/Application/Controllers/Api/V1/PostController.php
@@ -23,6 +23,7 @@ use App\Shared\Exceptions\StateTransitionException;
 use App\Shared\Exceptions\Validation\RequestValidationException;
 use App\Shared\Exceptions\ValidationException;
 use App\Shared\Helpers\NetworkHelper;
+use OpenApi\Attributes as OA;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Throwable;
@@ -831,5 +832,127 @@ class PostController extends BaseController implements PostApiInterface
     {
         return $this->authService->can($userId, 'post', 'manage')
             || $this->authService->can($userId, 'post', 'update');
+    }
+
+    #[OA\Get(
+        path: '/api/posts/export/markdown',
+        operationId: 'exportPostsMarkdown',
+        summary: '匯出多篇文章為 Markdown 格式',
+        tags: ['posts'],
+        parameters: [
+            new OA\Parameter(name: 'ids', in: 'query', schema: new OA\Schema(type: 'string'), description: '文章 ID 清單（逗號分隔）'),
+            new OA\Parameter(name: 'status', in: 'query', schema: new OA\Schema(type: 'string'), description: '篩選狀態'),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: '成功下載 Markdown 檔案'),
+        ],
+    )]
+    public function exportMarkdown(Request $request, Response $response): Response
+    {
+        try {
+            $queryParams = $request->getQueryParams();
+            $filters = [];
+            if (!empty($queryParams['ids']) && is_string($queryParams['ids'])) {
+                $rawIds = explode(',', $queryParams['ids']);
+                $filters['ids'] = array_filter(array_map('intval', $rawIds), static fn(int $id): bool => $id > 0);
+            }
+            if (!empty($queryParams['status']) && is_string($queryParams['status'])) {
+                $filters['status'] = trim($queryParams['status']);
+            }
+
+            $result = $this->postService->listPosts(1, 1000, $filters);
+            /** @var array<int, Post> $posts */
+            $posts = $result['items'];
+            $markdown = '';
+
+            foreach ($posts as $post) {
+                $markdown .= $this->formatPostToMarkdown($post) . "\n\n---\n\n";
+            }
+
+            $response->getBody()->write($markdown);
+
+            return $response
+                ->withStatus(200)
+                ->withHeader('Content-Type', 'text/markdown; charset=UTF-8')
+                ->withHeader('Content-Disposition', 'attachment; filename="posts_export.md"');
+        } catch (Throwable $e) {
+            $responseData = $this->handleException($e);
+            $response->getBody()->write($responseData);
+
+            return $response->withStatus(500)->withHeader('Content-Type', 'application/json');
+        }
+    }
+
+    #[OA\Get(
+        path: '/api/posts/{id}/export/markdown',
+        operationId: 'exportSinglePostMarkdown',
+        summary: '匯出單篇文章為 Markdown 格式',
+        tags: ['posts'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: '成功下載單篇 Markdown 檔案'),
+            new OA\Response(response: 404, description: '貼文不存在'),
+        ],
+    )]
+    public function exportSingleMarkdown(Request $request, Response $response): Response
+    {
+        try {
+            $idAttr = $request->getAttribute('id');
+            $id = is_numeric($idAttr) ? (int) $idAttr : 0;
+            $post = $this->postService->findById($id);
+
+            $markdown = $this->formatPostToMarkdown($post);
+            $filename = sprintf('post_%d.md', $id);
+
+            $response->getBody()->write($markdown);
+
+            return $response
+                ->withStatus(200)
+                ->withHeader('Content-Type', 'text/markdown; charset=UTF-8')
+                ->withHeader('Content-Disposition', sprintf('attachment; filename="%s"', $filename));
+        } catch (PostNotFoundException $e) {
+            $errorResponse = $this->errorResponse('貼文不存在', 404);
+            $response->getBody()->write($errorResponse);
+
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(404);
+        } catch (Throwable $e) {
+            $responseData = $this->handleException($e);
+            $response->getBody()->write($responseData);
+
+            return $response->withStatus(500)->withHeader('Content-Type', 'application/json');
+        }
+    }
+
+    private function formatPostToMarkdown(Post $post): string
+    {
+        $title = $post->getTitle();
+        $author = $post->getAuthor() ?: '系統管理員';
+        $createdAt = $post->getCreatedAt();
+        $statusStr = $post->getStatus()->value;
+        $content = $post->getContent();
+
+        $mdContent = preg_replace('/<h1[^>]*>(.*?)<\/h1>/i', "# $1\n\n", $content) ?? $content;
+        $mdContent = preg_replace('/<h2[^>]*>(.*?)<\/h2>/i', "## $1\n\n", $mdContent) ?? $mdContent;
+        $mdContent = preg_replace('/<h3[^>]*>(.*?)<\/h3>/i', "### $1\n\n", $mdContent) ?? $mdContent;
+        $mdContent = preg_replace('/<strong[^>]*>(.*?)<\/strong>/i', '**$1**', $mdContent) ?? $mdContent;
+        $mdContent = preg_replace('/<b[^>]*>(.*?)<\/b>/i', '**$1**', $mdContent) ?? $mdContent;
+        $mdContent = preg_replace('/<em[^>]*>(.*?)<\/em>/i', '*$1*', $mdContent) ?? $mdContent;
+        $mdContent = preg_replace('/<i[^>]*>(.*?)<\/i>/i', '*$1*', $mdContent) ?? $mdContent;
+        $mdContent = preg_replace('/<li[^>]*>(.*?)<\/li>/i', "- $1\n", $mdContent) ?? $mdContent;
+        $mdContent = preg_replace('/<p[^>]*>(.*?)<\/p>/i', "$1\n\n", $mdContent) ?? $mdContent;
+        $mdContent = preg_replace('/<br\s*\/?>/i', "\n", $mdContent) ?? $mdContent;
+        $cleanContent = trim(html_entity_decode(strip_tags($mdContent), ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+
+        return sprintf(
+            "# %s\n\n- **文章 ID**: %d\n- **作者**: %s\n- **發佈時間**: %s\n- **狀態**: %s\n\n---\n\n%s",
+            $title,
+            $post->getId(),
+            $author,
+            $createdAt,
+            $statusStr,
+            $cleanContent,
+        );
     }
 }

--- a/backend/app/Domains/Notification/Contracts/NotificationRepositoryInterface.php
+++ b/backend/app/Domains/Notification/Contracts/NotificationRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domains\Notification\Contracts;
+
+use App\Domains\Notification\DTOs\CreateNotificationDTO;
+use App\Domains\Notification\Models\Notification;
+
+interface NotificationRepositoryInterface
+{
+    /**
+     * @return array<int, Notification>
+     */
+    public function findForUser(?int $userId, bool $unreadOnly = false, int $limit = 20, int $offset = 0): array;
+
+    public function countUnreadForUser(?int $userId): int;
+
+    public function findById(int $id): ?Notification;
+
+    public function markAsRead(int $id, string $readAt): bool;
+
+    public function markAllAsReadForUser(?int $userId, string $readAt): int;
+
+    public function create(CreateNotificationDTO $dto): Notification;
+}

--- a/backend/app/Domains/Notification/Contracts/NotificationServiceInterface.php
+++ b/backend/app/Domains/Notification/Contracts/NotificationServiceInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domains\Notification\Contracts;
+
+use App\Domains\Notification\DTOs\CreateNotificationDTO;
+use App\Domains\Notification\Models\Notification;
+
+interface NotificationServiceInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function getUserNotifications(?int $userId, bool $unreadOnly = false, int $limit = 20, int $offset = 0): array;
+
+    public function getUnreadCount(?int $userId): int;
+
+    public function markAsRead(int $id, ?int $currentUserId): bool;
+
+    public function markAllAsRead(?int $userId): int;
+
+    public function broadcastNotification(CreateNotificationDTO $dto): Notification;
+}

--- a/backend/app/Domains/Notification/DTOs/CreateNotificationDTO.php
+++ b/backend/app/Domains/Notification/DTOs/CreateNotificationDTO.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domains\Notification\DTOs;
+
+class CreateNotificationDTO
+{
+    public function __construct(
+        public readonly ?int $userId,
+        public readonly string $title,
+        public readonly string $message,
+        public readonly string $type = 'system',
+    ) {}
+
+    /**
+     * @param array<mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $userId = isset($data['user_id']) && is_numeric($data['user_id']) ? (int) $data['user_id'] : null;
+        $title = isset($data['title']) && is_string($data['title']) ? $data['title'] : '';
+        $message = isset($data['message']) && is_string($data['message']) ? $data['message'] : '';
+        $type = isset($data['type']) && is_string($data['type']) ? $data['type'] : 'system';
+
+        return new self(
+            userId: $userId,
+            title: $title,
+            message: $message,
+            type: $type,
+        );
+    }
+}

--- a/backend/app/Domains/Notification/Models/Notification.php
+++ b/backend/app/Domains/Notification/Models/Notification.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domains\Notification\Models;
+
+use JsonSerializable;
+
+class Notification implements JsonSerializable
+{
+    public function __construct(
+        private readonly ?int $id,
+        private readonly string $uuid,
+        private readonly ?int $userId,
+        private readonly string $title,
+        private readonly string $message,
+        private readonly string $type,
+        private bool $isRead,
+        private ?string $readAt,
+        private readonly string $createdAt,
+    ) {}
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+
+    public function getUserId(): ?int
+    {
+        return $this->userId;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function isRead(): bool
+    {
+        return $this->isRead;
+    }
+
+    public function getReadAt(): ?string
+    {
+        return $this->readAt;
+    }
+
+    public function getCreatedAt(): string
+    {
+        return $this->createdAt;
+    }
+
+    public function markAsRead(string $readAt): void
+    {
+        $this->isRead = true;
+        $this->readAt = $readAt;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromDatabaseRow(array $row): self
+    {
+        $id = isset($row['id']) && is_numeric($row['id']) ? (int) $row['id'] : null;
+        $uuid = isset($row['uuid']) && is_string($row['uuid']) ? $row['uuid'] : '';
+        $userId = isset($row['user_id']) && is_numeric($row['user_id']) ? (int) $row['user_id'] : null;
+        $title = isset($row['title']) && is_string($row['title']) ? $row['title'] : '';
+        $message = isset($row['message']) && is_string($row['message']) ? $row['message'] : '';
+        $type = isset($row['type']) && is_string($row['type']) ? $row['type'] : 'system';
+        $isRead = !empty($row['is_read']);
+        $readAt = isset($row['read_at']) && is_string($row['read_at']) ? $row['read_at'] : null;
+        $createdAt = isset($row['created_at']) && is_string($row['created_at']) ? $row['created_at'] : date('Y-m-d H:i:s');
+
+        return new self(
+            id: $id,
+            uuid: $uuid,
+            userId: $userId,
+            title: $title,
+            message: $message,
+            type: $type,
+            isRead: $isRead,
+            readAt: $readAt,
+            createdAt: $createdAt,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'id'         => $this->id,
+            'uuid'       => $this->uuid,
+            'user_id'    => $this->userId,
+            'title'      => $this->title,
+            'message'    => $this->message,
+            'type'       => $this->type,
+            'is_read'    => $this->isRead,
+            'read_at'    => $this->readAt,
+            'created_at' => $this->createdAt,
+        ];
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/backend/app/Domains/Notification/Repositories/NotificationRepository.php
+++ b/backend/app/Domains/Notification/Repositories/NotificationRepository.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domains\Notification\Repositories;
+
+use App\Domains\Notification\Contracts\NotificationRepositoryInterface;
+use App\Domains\Notification\DTOs\CreateNotificationDTO;
+use App\Domains\Notification\Models\Notification;
+use PDO;
+use PDOException;
+use RuntimeException;
+
+class NotificationRepository implements NotificationRepositoryInterface
+{
+    private const TABLE_NAME = 'notifications';
+
+    private const SELECT_FIELDS = 'id, uuid, user_id, title, message, type, is_read, read_at, created_at';
+
+    public function __construct(
+        private readonly PDO $db,
+    ) {
+        $this->db->exec('PRAGMA foreign_keys = ON');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    }
+
+    /**
+     * @return array<int, Notification>
+     */
+    public function findForUser(?int $userId, bool $unreadOnly = false, int $limit = 20, int $offset = 0): array
+    {
+        try {
+            $sql = 'SELECT ' . self::SELECT_FIELDS . ' FROM ' . self::TABLE_NAME . ' WHERE ';
+            if ($userId !== null) {
+                $sql .= '(user_id = :user_id OR user_id IS NULL)';
+            } else {
+                $sql .= 'user_id IS NULL';
+            }
+
+            if ($unreadOnly) {
+                $sql .= ' AND is_read = 0';
+            }
+
+            $sql .= ' ORDER BY created_at DESC LIMIT :limit OFFSET :offset';
+
+            $stmt = $this->db->prepare($sql);
+            if ($userId !== null) {
+                $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+            }
+            $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+            $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+            $stmt->execute();
+
+            /** @var array<int, array<string, mixed>> $results */
+            $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+            return array_values(array_map(
+                static fn(array $row): Notification => Notification::fromDatabaseRow($row),
+                $results,
+            ));
+        } catch (PDOException $e) {
+            throw new RuntimeException('Failed to retrieve notifications: ' . $e->getMessage(), 0, $e);
+        }
+    }
+
+    public function countUnreadForUser(?int $userId): int
+    {
+        try {
+            $sql = 'SELECT COUNT(*) FROM ' . self::TABLE_NAME . ' WHERE is_read = 0 AND ';
+            if ($userId !== null) {
+                $sql .= '(user_id = :user_id OR user_id IS NULL)';
+            } else {
+                $sql .= 'user_id IS NULL';
+            }
+
+            $stmt = $this->db->prepare($sql);
+            if ($userId !== null) {
+                $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+            }
+            $stmt->execute();
+
+            return (int) $stmt->fetchColumn();
+        } catch (PDOException $e) {
+            throw new RuntimeException('Failed to count unread notifications: ' . $e->getMessage(), 0, $e);
+        }
+    }
+
+    public function findById(int $id): ?Notification
+    {
+        try {
+            $sql = 'SELECT ' . self::SELECT_FIELDS . ' FROM ' . self::TABLE_NAME . ' WHERE id = :id LIMIT 1';
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindValue(':id', $id, PDO::PARAM_INT);
+            $stmt->execute();
+
+            /** @var array<string, mixed>|false $row */
+            $row = $stmt->fetch(PDO::FETCH_ASSOC);
+            if (!$row) {
+                return null;
+            }
+
+            return Notification::fromDatabaseRow($row);
+        } catch (PDOException $e) {
+            throw new RuntimeException('Failed to find notification: ' . $e->getMessage(), 0, $e);
+        }
+    }
+
+    public function markAsRead(int $id, string $readAt): bool
+    {
+        try {
+            $sql = 'UPDATE ' . self::TABLE_NAME . ' SET is_read = 1, read_at = :read_at WHERE id = :id';
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindValue(':read_at', $readAt, PDO::PARAM_STR);
+            $stmt->bindValue(':id', $id, PDO::PARAM_INT);
+            $stmt->execute();
+
+            return $stmt->rowCount() > 0;
+        } catch (PDOException $e) {
+            throw new RuntimeException('Failed to mark notification as read: ' . $e->getMessage(), 0, $e);
+        }
+    }
+
+    public function markAllAsReadForUser(?int $userId, string $readAt): int
+    {
+        try {
+            $sql = 'UPDATE ' . self::TABLE_NAME . ' SET is_read = 1, read_at = :read_at WHERE is_read = 0 AND ';
+            if ($userId !== null) {
+                $sql .= '(user_id = :user_id OR user_id IS NULL)';
+            } else {
+                $sql .= 'user_id IS NULL';
+            }
+
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindValue(':read_at', $readAt, PDO::PARAM_STR);
+            if ($userId !== null) {
+                $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+            }
+            $stmt->execute();
+
+            return $stmt->rowCount();
+        } catch (PDOException $e) {
+            throw new RuntimeException('Failed to mark all notifications as read: ' . $e->getMessage(), 0, $e);
+        }
+    }
+
+    public function create(CreateNotificationDTO $dto): Notification
+    {
+        try {
+            $uuid = sprintf(
+                '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
+                mt_rand(0, 0xffff),
+                mt_rand(0, 0xffff),
+                mt_rand(0, 0xffff),
+                mt_rand(0, 0x0fff) | 0x4000,
+                mt_rand(0, 0x3fff) | 0x8000,
+                mt_rand(0, 0xffff),
+                mt_rand(0, 0xffff),
+                mt_rand(0, 0xffff),
+            );
+            $createdAt = date('Y-m-d H:i:s');
+
+            $sql = 'INSERT INTO ' . self::TABLE_NAME . ' (uuid, user_id, title, message, type, is_read, created_at)
+                    VALUES (:uuid, :user_id, :title, :message, :type, 0, :created_at)';
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindValue(':uuid', $uuid, PDO::PARAM_STR);
+            if ($dto->userId !== null) {
+                $stmt->bindValue(':user_id', $dto->userId, PDO::PARAM_INT);
+            } else {
+                $stmt->bindValue(':user_id', null, PDO::PARAM_NULL);
+            }
+            $stmt->bindValue(':title', $dto->title, PDO::PARAM_STR);
+            $stmt->bindValue(':message', $dto->message, PDO::PARAM_STR);
+            $stmt->bindValue(':type', $dto->type, PDO::PARAM_STR);
+            $stmt->bindValue(':created_at', $createdAt, PDO::PARAM_STR);
+            $stmt->execute();
+
+            $id = (int) $this->db->lastInsertId();
+
+            return new Notification(
+                id: $id,
+                uuid: $uuid,
+                userId: $dto->userId,
+                title: $dto->title,
+                message: $dto->message,
+                type: $dto->type,
+                isRead: false,
+                readAt: null,
+                createdAt: $createdAt,
+            );
+        } catch (PDOException $e) {
+            throw new RuntimeException('Failed to create notification: ' . $e->getMessage(), 0, $e);
+        }
+    }
+}

--- a/backend/app/Domains/Notification/Services/NotificationService.php
+++ b/backend/app/Domains/Notification/Services/NotificationService.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domains\Notification\Services;
+
+use App\Domains\Notification\Contracts\NotificationRepositoryInterface;
+use App\Domains\Notification\Contracts\NotificationServiceInterface;
+use App\Domains\Notification\DTOs\CreateNotificationDTO;
+use App\Domains\Notification\Models\Notification;
+use RuntimeException;
+
+class NotificationService implements NotificationServiceInterface
+{
+    public function __construct(
+        private readonly NotificationRepositoryInterface $repository,
+    ) {}
+
+    public function getUserNotifications(?int $userId, bool $unreadOnly = false, int $limit = 20, int $offset = 0): array
+    {
+        $notifications = $this->repository->findForUser($userId, $unreadOnly, $limit, $offset);
+        $unreadCount = $this->repository->countUnreadForUser($userId);
+
+        return [
+            'notifications' => array_map(static fn(Notification $n): array => $n->toArray(), $notifications),
+            'unread_count'  => $unreadCount,
+            'limit'         => $limit,
+            'offset'        => $offset,
+        ];
+    }
+
+    public function getUnreadCount(?int $userId): int
+    {
+        return $this->repository->countUnreadForUser($userId);
+    }
+
+    public function markAsRead(int $id, ?int $currentUserId): bool
+    {
+        $notification = $this->repository->findById($id);
+        if (!$notification) {
+            throw new RuntimeException('找不到指定的站內通知');
+        }
+
+        if ($notification->getUserId() !== null && $notification->getUserId() !== $currentUserId) {
+            throw new RuntimeException('無權限操作此通知');
+        }
+
+        $readAt = date('Y-m-d H:i:s');
+
+        return $this->repository->markAsRead($id, $readAt);
+    }
+
+    public function markAllAsRead(?int $userId): int
+    {
+        $readAt = date('Y-m-d H:i:s');
+
+        return $this->repository->markAllAsReadForUser($userId, $readAt);
+    }
+
+    public function broadcastNotification(CreateNotificationDTO $dto): Notification
+    {
+        if (trim($dto->title) === '' || trim($dto->message) === '') {
+            throw new RuntimeException('通知標題與內容不能為空');
+        }
+
+        return $this->repository->create($dto);
+    }
+}

--- a/backend/app/Domains/Post/Models/Post.php
+++ b/backend/app/Domains/Post/Models/Post.php
@@ -167,6 +167,11 @@ class Post implements JsonSerializable
         return $this->creationSourceDetail;
     }
 
+    public function getAuthor(): ?string
+    {
+        return $this->author;
+    }
+
     /**
      * @return list<array{id: int, name: string}>
      */

--- a/backend/app/Infrastructure/Routing/Providers/RoutingServiceProvider.php
+++ b/backend/app/Infrastructure/Routing/Providers/RoutingServiceProvider.php
@@ -99,6 +99,7 @@ class RoutingServiceProvider
             'activity-logs'  => __DIR__ . '/../../../../config/routes/activity-logs.php',
             'tag-management' => __DIR__ . '/../../../../config/routes/tag-management.php',
             'cache-monitor'  => __DIR__ . '/../../../../config/routes/cache-monitor.php',
+            'notifications'  => __DIR__ . '/../../../../config/routes/notifications.php',
         ];
     }
 

--- a/backend/config/container.php
+++ b/backend/config/container.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 use App\Application\Controllers\Admin\CacheMonitorController;
 use App\Application\Controllers\Admin\TagManagementController;
+use App\Application\Controllers\Api\V1\NotificationController;
 use App\Application\Controllers\Api\V1\PostViewController;
 use App\Application\Controllers\Api\V1\RoleController;
 use App\Application\Controllers\Api\V1\UserController;
@@ -24,6 +25,10 @@ use App\Domains\Auth\Repositories\UserRepository;
 use App\Domains\Auth\Services\AuthorizationService;
 use App\Domains\Auth\Services\RoleManagementService;
 use App\Domains\Auth\Services\UserManagementService;
+use App\Domains\Notification\Contracts\NotificationRepositoryInterface;
+use App\Domains\Notification\Contracts\NotificationServiceInterface;
+use App\Domains\Notification\Repositories\NotificationRepository;
+use App\Domains\Notification\Services\NotificationService;
 use App\Domains\Post\Contracts\PostRepositoryInterface;
 use App\Domains\Post\Contracts\PostServiceInterface;
 use App\Domains\Post\Contracts\TagRepositoryInterface;
@@ -351,6 +356,18 @@ return array_merge(
 
         RoleController::class => \DI\autowire(RoleController::class)
             ->constructorParameter('roleManagementService', \DI\get(RoleManagementService::class)),
+
+        // ========================================
+        // 站內通知模組
+        // ========================================
+        NotificationRepositoryInterface::class => \DI\autowire(NotificationRepository::class)
+            ->constructorParameter('db', \DI\get(PDO::class)),
+
+        NotificationServiceInterface::class => \DI\autowire(NotificationService::class)
+            ->constructorParameter('repository', \DI\get(NotificationRepositoryInterface::class)),
+
+        NotificationController::class => \DI\autowire(NotificationController::class)
+            ->constructorParameter('notificationService', \DI\get(NotificationServiceInterface::class)),
     ],
 
     // 監控服務

--- a/backend/config/routes/api.php
+++ b/backend/config/routes/api.php
@@ -46,6 +46,20 @@ return [
         'name' => 'posts.index'
     ],
 
+    'posts.export_markdown' => [
+        'methods' => ['GET'],
+        'path' => '/api/posts/export/markdown',
+        'handler' => [PostController::class, 'exportMarkdown'],
+        'name' => 'posts.export_markdown'
+    ],
+
+    'posts.export_single_markdown' => [
+        'methods' => ['GET'],
+        'path' => '/api/posts/{id}/export/markdown',
+        'handler' => [PostController::class, 'exportSingleMarkdown'],
+        'name' => 'posts.export_single_markdown'
+    ],
+
     'posts.show' => [
         'methods' => ['GET'],
         'path' => '/api/posts/{id}',

--- a/backend/config/routes/notifications.php
+++ b/backend/config/routes/notifications.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\Controllers\Api\V1\NotificationController;
+
+return [
+    'notifications.index' => [
+        'methods'    => ['GET'],
+        'path'       => '/api/notifications',
+        'handler'    => [NotificationController::class, 'index'],
+        'name'       => 'notifications.index',
+        'middleware' => ['auth'],
+    ],
+
+    'notifications.unread_count' => [
+        'methods'    => ['GET'],
+        'path'       => '/api/notifications/unread-count',
+        'handler'    => [NotificationController::class, 'unreadCount'],
+        'name'       => 'notifications.unread_count',
+        'middleware' => ['auth'],
+    ],
+
+    'notifications.mark_as_read' => [
+        'methods'    => ['PATCH'],
+        'path'       => '/api/notifications/{id}/read',
+        'handler'    => [NotificationController::class, 'markAsRead'],
+        'name'       => 'notifications.mark_as_read',
+        'middleware' => ['auth'],
+    ],
+
+    'notifications.mark_all_as_read' => [
+        'methods'    => ['PATCH'],
+        'path'       => '/api/notifications/read-all',
+        'handler'    => [NotificationController::class, 'markAllAsRead'],
+        'name'       => 'notifications.mark_all_as_read',
+        'middleware' => ['auth'],
+    ],
+
+    'notifications.broadcast' => [
+        'methods'    => ['POST'],
+        'path'       => '/api/notifications/broadcast',
+        'handler'    => [NotificationController::class, 'broadcast'],
+        'name'       => 'notifications.broadcast',
+        'middleware' => ['auth', 'admin'],
+    ],
+];

--- a/backend/database/migrations/20251016000000_create_notifications_table.php
+++ b/backend/database/migrations/20251016000000_create_notifications_table.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * 建立站內通知資料表.
+ */
+final class CreateNotificationsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $table = $this->table('notifications', ['id' => false, 'primary_key' => 'id']);
+        $table
+            ->addColumn('id', 'integer', ['identity' => true, 'signed' => false])
+            ->addColumn('uuid', 'string', ['limit' => 36, 'null' => false])
+            ->addColumn('user_id', 'integer', ['null' => true, 'comment' => '接收通知的使用者 ID (null 表示全體廣播)'])
+            ->addColumn('title', 'string', ['limit' => 255, 'null' => false, 'comment' => '通知標題'])
+            ->addColumn('message', 'text', ['null' => false, 'comment' => '通知內容'])
+            ->addColumn('type', 'string', ['limit' => 50, 'default' => 'system', 'comment' => '通知類型 (system, post, security)'])
+            ->addColumn('is_read', 'boolean', ['default' => false, 'null' => false, 'comment' => '是否已讀'])
+            ->addColumn('read_at', 'timestamp', ['null' => true, 'comment' => '已讀時間'])
+            ->addColumn('created_at', 'timestamp', ['default' => 'CURRENT_TIMESTAMP', 'comment' => '建立時間'])
+            ->addIndex('uuid', ['unique' => true, 'name' => 'idx_notifications_uuid'])
+            ->addIndex('user_id', ['name' => 'idx_notifications_user_id'])
+            ->addIndex('is_read', ['name' => 'idx_notifications_is_read'])
+            ->create();
+
+        // 插入預設通知範例資料
+        $this->table('notifications')->insert([
+            [
+                'uuid' => '550e8400-e29b-41d4-a716-446655440001',
+                'user_id' => null,
+                'title' => '歡迎使用 AlleyNote 系統',
+                'message' => 'AlleyNote 公告系統已完成建置與功能擴充，歡迎體驗使用！',
+                'type' => 'system',
+                'is_read' => false,
+            ],
+            [
+                'uuid' => '550e8400-e29b-41d4-a716-446655440002',
+                'user_id' => 1,
+                'title' => '系統安全性通知',
+                'message' => '您的管理員帳號權限已升級並生效。',
+                'type' => 'security',
+                'is_read' => false,
+            ],
+        ])->saveData();
+    }
+}

--- a/backend/tests/Unit/Notification/NotificationServiceTest.php
+++ b/backend/tests/Unit/Notification/NotificationServiceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Notification;
+
+use App\Domains\Notification\Contracts\NotificationRepositoryInterface;
+use App\Domains\Notification\DTOs\CreateNotificationDTO;
+use App\Domains\Notification\Models\Notification;
+use App\Domains\Notification\Services\NotificationService;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class NotificationServiceTest extends TestCase
+{
+    public function testGetNotifications(): void
+    {
+        $mockRepo = $this->createMock(NotificationRepositoryInterface::class);
+        $sampleNotification = new Notification(
+            id: 1,
+            uuid: 'test-uuid-1',
+            userId: 10,
+            title: '測試通知',
+            message: '測試內容',
+            type: 'system',
+            isRead: false,
+            readAt: null,
+            createdAt: '2026-08-07 10:00:00',
+        );
+
+        $mockRepo->expects($this->once())
+            ->method('findForUser')
+            ->with(10, false, 20, 0)
+            ->willReturn([$sampleNotification]);
+
+        $mockRepo->expects($this->once())
+            ->method('countUnreadForUser')
+            ->with(10)
+            ->willReturn(1);
+
+        $service = new NotificationService($mockRepo);
+        $result = $service->getUserNotifications(10, false, 20, 0);
+
+        $this->assertEquals(1, $result['unread_count']);
+        /** @var array<int, array<string, mixed>> $notifications */
+        $notifications = $result['notifications'];
+        $this->assertCount(1, $notifications);
+        $this->assertEquals('測試通知', $notifications[0]['title']);
+    }
+
+    public function testBroadcastNotification(): void
+    {
+        $mockRepo = $this->createMock(NotificationRepositoryInterface::class);
+        $dto = new CreateNotificationDTO(null, '全體公告', '廣播訊息內容', 'system');
+        $notification = new Notification(
+            id: 2,
+            uuid: 'test-uuid-2',
+            userId: null,
+            title: '全體公告',
+            message: '廣播訊息內容',
+            type: 'system',
+            isRead: false,
+            readAt: null,
+            createdAt: '2026-08-07 10:00:00',
+        );
+
+        $mockRepo->expects($this->once())
+            ->method('create')
+            ->with($dto)
+            ->willReturn($notification);
+
+        $service = new NotificationService($mockRepo);
+        $res = $service->broadcastNotification($dto);
+
+        $this->assertEquals('全體公告', $res->getTitle());
+    }
+
+    public function testBroadcastNotificationThrowsOnEmptyTitle(): void
+    {
+        $mockRepo = $this->createMock(NotificationRepositoryInterface::class);
+        $dto = new CreateNotificationDTO(null, '', '內容', 'system');
+
+        $service = new NotificationService($mockRepo);
+
+        $this->expectException(RuntimeException::class);
+        $service->broadcastNotification($dto);
+    }
+}


### PR DESCRIPTION
## 變更摘要
新增文章 Markdown 匯出端點與全功能站內通知系統端點，依循 DDD 架構規範完成 Migration、Domain 模型、Repository、Service、Controller 與單元測試。

### commit 列表
- `feat(api): 新增文章 Markdown 匯出端點與站內通知系統端點`

## 主要變更項目

### 後端 Domain / Controller / Route
- `backend/app/Application/Controllers/Api/V1/PostController.php`: 新增 `exportMarkdown` 與 `exportSingleMarkdown` 方法，支援批次與單篇 Markdown 下載。
- `backend/app/Domains/Post/Models/Post.php`: 新增 `getAuthor()` Getter 方法。
- `backend/app/Domains/Notification/*`: 建立 Notification 領域模型、DTO、Contracts、Repository 與 Service。
- `backend/app/Application/Controllers/Api/V1/NotificationController.php`: 建立站內通知控制器，提供列表、未讀計數、已讀標記與廣播端點。
- `backend/config/routes/notifications.php`: 新增站內通知路由配置。
- `backend/config/routes/api.php`: 註冊文章 Markdown 匯出路由。
- `backend/config/container.php`: 配置 Notification 模組之 DI 容器依賴注入與介面綁定。
- `backend/database/migrations/20251016000000_create_notifications_table.php`: 建立 `notifications` 資料表與索引 Phinx 遷移檔。

### 測試
- `backend/tests/Unit/Notification/NotificationServiceTest.php`: 新增 NotificationService 單元測試。

## 測試與驗證
- [x] 本地全單元與整合測試 (`composer check-all` 通過 2,331 / 2,331 測試)
- [x] PHPStan Level 10 靜態分析檢查 (`0 errors`)
- [x] PHP-CS-Fixer 程式碼風格自動修正與檢查 (`0 errors`)
- [x] Live HTTP API 實測驗證（包含匯出端點、通知列表、未讀數、標記已讀與廣播發送 7 個端點均回傳 200 OK / 201 Created）

## 風險與回滾
- **風險等級**: 低
- **回滾方式**: 若需回滾，可直接執行 `git revert` 並執行 Phinx rollback 撤銷 `notifications` 資料表。
